### PR TITLE
rename default endpoint to "/metrics"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ duration of jobs and pipeline stages
 
 `PROMETHEUS_NAMESPACE` Prefix of metric (Default: `default`).
 
-`PROMETHEUS_ENDPOINT` REST Endpoint (Default: `prometheus`)
+`PROMETHEUS_ENDPOINT` REST Endpoint (Default: `metrics`)
 
 ## Building
 `mvn hpi:hpi`

--- a/src/main/java/org/jenkinsci/plugins/prometheus/rest/PrometheusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/rest/PrometheusAction.java
@@ -12,7 +12,7 @@ import org.jenkinsci.plugins.prometheus.MetricsRequest;
 public class PrometheusAction implements UnprotectedRootAction {
     private CollectorRegistry collectorRegistry;
     private JobCollector jobCollector = new JobCollector();
-    private static final String DEFAULT_ENDPOINT = "prometheus";
+    private static final String DEFAULT_ENDPOINT = "metrics";
     private String prometheusEndpoint;
 
     @Override


### PR DESCRIPTION
This makes the plugin in line with the expected defaults in the
prometheus ecosystem.

This partially fixes #5.