### PR TITLE
Allow slashes in path and add authentication for the metrics endpoint

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -1,0 +1,76 @@
+package org.jenkinsci.plugins.prometheus.config;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Robin Müller
+ */
+@Extension
+public class PrometheusConfiguration extends GlobalConfiguration {
+
+    private static final String PROMETHEUS_ENDPOINT = "PROMETHEUS_ENDPOINT";
+    private static final String DEFAULT_ENDPOINT = "prometheus";
+
+    private String urlName;
+    private String additionalPath;
+
+    public PrometheusConfiguration() {
+        load();
+        if (urlName == null) {
+            Map<String, String> env = System.getenv();
+            setPath(env.containsKey(PROMETHEUS_ENDPOINT) ? env.get(PROMETHEUS_ENDPOINT) : DEFAULT_ENDPOINT);
+        }
+    }
+
+    public static PrometheusConfiguration get() {
+        Descriptor configuration = Jenkins.getActiveInstance().getDescriptor(PrometheusConfiguration.class);
+        return (PrometheusConfiguration) configuration;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        setPath(json.getString("path"));
+        save();
+        return super.configure(req, json);
+    }
+
+    public void setPath(String path) {
+        urlName = path.split("/")[0];
+        List<String> pathParts = Arrays.asList(path.split("/"));
+        additionalPath = (pathParts.size() > 1 ? "/" : "") + StringUtils.join(pathParts.subList(1, pathParts.size()), "/");
+    }
+
+    public String getPath() {
+        return StringUtils.isEmpty(additionalPath) ? urlName : urlName + "/" + additionalPath;
+    }
+
+    public String getUrlName() {
+        return urlName;
+    }
+
+    public String getAdditionalPath() {
+        return additionalPath;
+    }
+
+    public FormValidation doCheckPath(@QueryParameter String value) {
+        if (StringUtils.isEmpty(value)) {
+            return FormValidation.error(Messages.path_required());
+        } else if (System.getenv().containsKey(PROMETHEUS_ENDPOINT)) {
+            return FormValidation.warning(Messages.path_environment_override(PROMETHEUS_ENDPOINT, System.getenv(PROMETHEUS_ENDPOINT)));
+        } else {
+            return FormValidation.ok();
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -25,6 +25,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     private String urlName;
     private String additionalPath;
+    private boolean useAuthenticatedEndpoint;
 
     public PrometheusConfiguration() {
         load();
@@ -42,8 +43,13 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
         setPath(json.getString("path"));
+        useAuthenticatedEndpoint = json.getBoolean("useAuthenticatedEndpoint");
         save();
         return super.configure(req, json);
+    }
+
+    public String getPath() {
+        return StringUtils.isEmpty(additionalPath) ? urlName : urlName + "/" + additionalPath;
     }
 
     public void setPath(String path) {
@@ -52,8 +58,12 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         additionalPath = (pathParts.size() > 1 ? "/" : "") + StringUtils.join(pathParts.subList(1, pathParts.size()), "/");
     }
 
-    public String getPath() {
-        return StringUtils.isEmpty(additionalPath) ? urlName : urlName + "/" + additionalPath;
+    public boolean isUseAuthenticatedEndpoint() {
+        return useAuthenticatedEndpoint;
+    }
+
+    void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
+        this.useAuthenticatedEndpoint = useAuthenticatedEndpoint;
     }
 
     public String getUrlName() {

--- a/src/main/java/org/jenkinsci/plugins/prometheus/rest/PrometheusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/rest/PrometheusAction.java
@@ -3,10 +3,14 @@ package org.jenkinsci.plugins.prometheus.rest;
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.model.UnprotectedRootAction;
+import hudson.security.Messages;
+import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import jenkins.metrics.api.Metrics;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.prometheus.JobCollector;
 import org.jenkinsci.plugins.prometheus.MetricsRequest;
 import org.jenkinsci.plugins.prometheus.config.PrometheusConfiguration;
@@ -34,6 +38,7 @@ public class PrometheusAction implements UnprotectedRootAction {
 
     public Object doDynamic(StaplerRequest request) {
         if (request.getRestOfPath().equals(PrometheusConfiguration.get().getAdditionalPath())) {
+            checkPermission(Metrics.VIEW);
             if (collectorRegistry == null) {
                 collectorRegistry = CollectorRegistry.defaultRegistry;
                 collectorRegistry.register(jobCollector);
@@ -44,5 +49,16 @@ public class PrometheusAction implements UnprotectedRootAction {
             return MetricsRequest.prometheusResponse(collectorRegistry);
         }
         throw HttpResponses.notFound();
+    }
+
+    private void checkPermission(Permission permission) {
+        if (PrometheusConfiguration.get().isUseAuthenticatedEndpoint()) {
+            Authentication authentication = Jenkins.getAuthentication();
+            if (!Jenkins.getActiveInstance().getACL().hasPermission(authentication, permission)) {
+                String message = Messages.AccessDeniedException2_MissingPermission(authentication.getName(),
+                                                                                   permission.group.title + "/" + permission.name);
+                throw HttpResponses.errorWithoutStack(403, message);
+            }
+        }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/Messages.properties
@@ -1,0 +1,2 @@
+path.required=Path is required.
+path.environment.override=You have still configured the environment variable {0} ({1}) which will be overwritten by this path.

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -4,5 +4,8 @@
     <f:entry title="${%Path}" field="path">
       <f:textbox/>
     </f:entry>
+    <f:entry title="${%Enable authentication for prometheus end-point}" field="useAuthenticatedEndpoint">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="Prometheus">
+    <f:entry title="${%Path}" field="path">
+      <f:textbox/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      The path where the prometheus metrics should be provided.
+    </p>
+  </div>
+</j:jelly>


### PR DESCRIPTION
The PR will add the following new features to the plugin:
1. add possibility to configure the plugin within the global settings of the Jenkins not via an environment variable
2. allow slashes in the prometheus endpoint path
3. add possibility to enable authentication for the prometheus endpoint