### PR TITLE
Add option to process or ignore disabled jobs.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -34,7 +34,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     private boolean countNotBuiltBuilds = true;
     private boolean countAbortedBuilds = true;
 
-    private boolean processingDisabledBuilds = true;
+    private boolean processingDisabledBuilds = false;
 
     public PrometheusConfiguration() {
         load();

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -33,7 +33,8 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     private boolean countFailedBuilds = true;
     private boolean countNotBuiltBuilds = true;
     private boolean countAbortedBuilds = true;
-    
+
+    private boolean processingDisabledBuilds = true;
 
     public PrometheusConfiguration() {
         load();
@@ -59,7 +60,9 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         countFailedBuilds = json.getBoolean("countFailedBuilds");
         countNotBuiltBuilds = json.getBoolean("countNotBuiltBuilds");
         countAbortedBuilds = json.getBoolean("countAbortedBuilds");
-        
+
+        processingDisabledBuilds = json.getBoolean("processingDisabledBuilds");
+
         save();
         return super.configure(req, json);
     }
@@ -128,6 +131,14 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     
     void setCountAbortedBuilds(boolean countAbortedBuilds) {
         this.countAbortedBuilds = countAbortedBuilds;
+    }
+
+    public boolean isProcessingDisabledBuilds() {
+        return processingDisabledBuilds;
+    }
+
+    void setProcessingDisabledBuilds(boolean processingDisabledBuilds) {
+        this.processingDisabledBuilds = processingDisabledBuilds;
     }
 
     public String getUrlName() {

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -25,5 +25,8 @@
     <f:entry title="${%Count duration of aborted builds}" field="countAbortedBuilds">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Ignore disabled jobs}" field="processingDisabledBuilds">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
@@ -40,4 +40,9 @@
       Count the duration of aborted builds.
     </p>
   </div>
+  <div>
+    <p>
+      Ignore disabled jobs.
+    </p>
+  </div>
 </j:jelly>


### PR DESCRIPTION
There is no need to take in account / send metrics about disable jobs.

# Notes

If this options is enable the values of *_duration_milliseconds_summary* will have a "bump"