### PR TITLE
Allow to configure fetching of test results from builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -219,7 +219,7 @@ public class JobCollector extends Collector {
         jobDuration.labels(labelValueArray).set(duration);
         jobScore.labels(labelValueArray).set(score);
 
-        if(hasTestResults(run)) {
+        if(PrometheusConfiguration.get().isFetchTestResults() && hasTestResults(run)) {
             int testsTotal = run.getAction(AbstractTestResultAction.class).getTotalCount();
             int testsFail = run.getAction(AbstractTestResultAction.class).getFailCount();
             int testsSkipped = run.getAction(AbstractTestResultAction.class).getSkipCount();

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -33,6 +33,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     private boolean countFailedBuilds = true;
     private boolean countNotBuiltBuilds = true;
     private boolean countAbortedBuilds = true;
+    private boolean fetchTestResults = true;
 
     private boolean processingDisabledBuilds = false;
 
@@ -60,6 +61,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         countFailedBuilds = json.getBoolean("countFailedBuilds");
         countNotBuiltBuilds = json.getBoolean("countNotBuiltBuilds");
         countAbortedBuilds = json.getBoolean("countAbortedBuilds");
+        fetchTestResults = json.getBoolean("fetchTestResults");
 
         processingDisabledBuilds = json.getBoolean("processingDisabledBuilds");
 
@@ -131,6 +133,14 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     
     void setCountAbortedBuilds(boolean countAbortedBuilds) {
         this.countAbortedBuilds = countAbortedBuilds;
+    }
+
+    public boolean isFetchTestResults() {
+        return fetchTestResults;
+    }
+
+    public void setFetchTestResults(boolean fetchTestResults) {
+        this.fetchTestResults = fetchTestResults;
     }
 
     public boolean isProcessingDisabledBuilds() {

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -25,6 +25,9 @@
     <f:entry title="${%Count duration of aborted builds}" field="countAbortedBuilds">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Fetch the test results of builds}" field="fetchTestResults">
+      <f:checkbox/>
+    </f:entry>
     <f:entry title="${%Ignore disabled jobs}" field="processingDisabledBuilds">
       <f:checkbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
@@ -42,6 +42,11 @@
   </div>
   <div>
     <p>
+      Fetch the test results of builds.
+    </p>
+  </div>
+  <div>
+    <p>
       Ignore disabled jobs.
     </p>
   </div>


### PR DESCRIPTION
Use case:

We have a Jenkins with almost 2k jobs. When Prometheus plugin is collecting the test results of the builds, the scarped JSON will grow by approx. 6k lines.
Thus I made the fetching of build test results configurable.