### PR TITLE
Adding a basic unit test to show that the abort works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,5 +116,11 @@
       <artifactId>simpleclient_dropwizard</artifactId>
       <version>${prometheus.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.9.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/prometheus/util/FlowNodesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/util/FlowNodesTest.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.prometheus.util;
+
+import org.jenkinsci.plugins.workflow.actions.StageAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jenkinsci.plugins.prometheus.util.FlowNodes.getSortedStageNodes;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlowNodesTest {
+
+    @Test
+    public void validateAbortWhenSameNodeIsEncountered() {
+        FlowNode topNode = mock(FlowNode.class);
+        List<FlowNode> nodeList = new ArrayList<>();
+        nodeList.add(topNode);
+        when(topNode.getId()).thenReturn("999");
+        when(topNode.getParents()).thenReturn(nodeList);
+        when(topNode.getAction(StageAction.class)).thenReturn(mock(StageAction.class));
+        List<FlowNode> sortedNodes = getSortedStageNodes(nodeList);
+        assertEquals(1, sortedNodes.size());
+    }
+}


### PR DESCRIPTION
This was developed alongside #47 to validate the abort works when it encounters something that is already in the list