### PR TITLE
Add in Prometheus default java metric exports.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
 
     <dependency>
       <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+      <version>${prometheus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>${prometheus.version}</version>
     </dependency>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/rest/PrometheusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/rest/PrometheusAction.java
@@ -8,6 +8,7 @@ import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.hotspot.DefaultExports;
 import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
@@ -48,6 +49,7 @@ public class PrometheusAction implements UnprotectedRootAction {
                 if (Metrics.metricRegistry() != null) {
                     collectorRegistry.register(new DropwizardExports(Metrics.metricRegistry()));
                 }
+                DefaultExports.initialize();
             }
             return MetricsRequest.prometheusResponse(collectorRegistry);
         }


### PR DESCRIPTION
Add in Prometheus default java metric exports. Includes metrics for garbage collection, memory pools, JMX, classloading, and thread counts. Useful as it uses the standard java metric names allowing generic jvm alert rules to be used against the Jenkins Prometheus plugin. 

See -- https://github.com/prometheus/client_java#included-collectors

In summary add the following metrics:
```
jvm_classes_loaded
jvm_classes_loaded_total
jvm_classes_unloaded_total
jvm_gc_collection_seconds_count
jvm_gc_collection_seconds_count
jvm_gc_collection_seconds_sum
jvm_gc_collection_seconds_sum
jvm_info
jvm_memory_bytes_committed
jvm_memory_bytes_committed
jvm_memory_bytes_max
jvm_memory_bytes_max
jvm_memory_bytes_used
jvm_memory_bytes_used
jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_committed
jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_max
jvm_memory_pool_bytes_used
jvm_memory_pool_bytes_used
jvm_memory_pool_bytes_used
jvm_memory_pool_bytes_used
jvm_memory_pool_bytes_used
jvm_memory_pool_bytes_used
jvm_threads_current
jvm_threads_daemon
jvm_threads_deadlocked
jvm_threads_deadlocked_monitor
jvm_threads_peak
jvm_threads_started_total
```