### PR TITLE
Update java_client to latest 0.6.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <inceptionYear>2016</inceptionYear>
 
   <properties>
-    <prometheus.version>0.0.26</prometheus.version>
+    <prometheus.version>0.6.0</prometheus.version>
     <workflow.api.version>1.8</workflow.api.version>
   </properties>
 


### PR DESCRIPTION
Updating java_client to v0.6.0 adds the following new DefaultExports. 

```
jvm_threads_state{state="BLOCKED"}                                                                                      
jvm_threads_state{state="NEW"}                                                                                          
jvm_threads_state{state="RUNNABLE"}                                                                                     
jvm_threads_state{state="TERMINATED"}                                                                                   
jvm_threads_state{state="TIMED_WAITING"}                                                                                
jvm_threads_state{state="WAITING"}                                                                                      
jvm_memory_pool_bytes_init{pool="Code Cache"}                                                                           
jvm_memory_pool_bytes_init{pool="Compressed Class Space"}                                                               
jvm_memory_pool_bytes_init{pool="Metaspace"}                                                                            
jvm_memory_pool_bytes_init{pool="PS Eden Space"}                                                                        
jvm_memory_pool_bytes_init{pool="PS Old Gen"}                                                                           
jvm_memory_pool_bytes_init{pool="PS Survivor Space"}                                                                    
jvm_memory_pool_allocated_bytes_total{pool="Code Cache"}                                                                
jvm_memory_pool_allocated_bytes_total{pool="Compressed Class Space"}                                                    
jvm_memory_pool_allocated_bytes_total{pool="Metaspace"}                                                                 
jvm_memory_pool_allocated_bytes_total{pool="PS Eden Space"}                                                             
jvm_memory_pool_allocated_bytes_total{pool="PS Old Gen"}                                                                
jvm_memory_pool_allocated_bytes_total{pool="PS Survivor Space"}                                                         
jvm_memory_bytes_init{area="heap"}                                                                                      
jvm_memory_bytes_init{area="nonheap"}                                                                                   
jvm_buffer_pool_used_buffers{pool="direct"}                                                                             
jvm_buffer_pool_used_buffers{pool="mapped"}                                                                             
jvm_buffer_pool_used_bytes{pool="direct"}                                                                               
jvm_buffer_pool_used_bytes{pool="mapped"}                                                                               
jvm_classes_loaded                                                                                                      
jvm_buffer_pool_capacity_bytes{pool="direct"}                                                                           
jvm_buffer_pool_capacity_bytes{pool="mapped"}
```

There are no breaking changes jumping from 0.0.26 to 0.6.0. Tested in my environment without any issues. 