### PR TITLE
Cache-Control on Prometheus endpoint

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/MetricsRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/MetricsRequest.java
@@ -17,6 +17,8 @@ public class MetricsRequest {
             public void generateResponse(StaplerRequest request, StaplerResponse response, Object node) throws IOException, ServletException {
                 response.setStatus(StaplerResponse.SC_OK);
                 response.setContentType(TextFormat.CONTENT_TYPE_004);
+                response.addHeader("Cache-Control","must-revalidate,no-cache,no-store");
+
 
                 StringWriter buffer = new StringWriter();
                 TextFormat.write004(buffer, collectorRegistry.metricFamilySamples());


### PR DESCRIPTION
This change adds a `Cache-Control` header on the endpoint so that reverse proxies and load balancers in front of Jenkins do not cache metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/prometheus-plugin/96)
<!-- Reviewable:end -->
