### PR TITLE
Adding disk usage metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <workflow.api.version>2.15</workflow.api.version>
     <jenkins.metrics.version>4.0.2.5</jenkins.metrics.version>
     <jenkins.junit.version>1.2</jenkins.junit.version>
+    <jenkins.diskUsage.version>0.9</jenkins.diskUsage.version>
     <gson.version>2.3.1</gson.version>
     <JUnitParams.version>1.0.4</JUnitParams.version>
     <httpcore.version>4.4</httpcore.version>
@@ -121,6 +122,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <version>${jenkins.junit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-disk-usage-simple</artifactId>
+      <version>${jenkins.diskUsage.version}</version>
     </dependency>
 
     <!-- Test only -->

--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -19,8 +19,6 @@ public class DiskUsageCollector extends Collector {
     private Jenkins jenkins;
     private Gauge directoryUsageGauge;
     private Gauge jobUsageGauge;
-    private static final String[] directoryLabels = {"directory"};
-    private static final String[] jobLabels = {"jobName", "url"};
 
     public DiskUsageCollector() {
         jenkins = Jenkins.get();
@@ -28,14 +26,14 @@ public class DiskUsageCollector extends Collector {
                 .namespace(ConfigurationUtils.getNamespace())
                 .subsystem(ConfigurationUtils.getSubSystem())
                 .name("disk_usage_bytes")
-                .labelNames(directoryLabels)
+                .labelNames("directory")
                 .help("Disk usage of first level folder in JENKINS_HOME in bytes")
                 .create();
         jobUsageGauge = Gauge.build()
                 .namespace(ConfigurationUtils.getNamespace())
                 .subsystem(ConfigurationUtils.getSubSystem())
                 .name("job_usage_bytes")
-                .labelNames(jobLabels)
+                .labelNames("jobName", "url")
                 .help("Amount of disk usage (bytes) for each job in Jenkins")
                 .create();
     }

--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -27,14 +27,14 @@ public class DiskUsageCollector extends Collector {
         directoryUsageGauge = Gauge.build()
                 .namespace(ConfigurationUtils.getNamespace())
                 .subsystem(ConfigurationUtils.getSubSystem())
-                .name("disk_usage")
+                .name("disk_usage_bytes")
                 .labelNames(directoryLabels)
                 .help("Disk usage of first level folder in JENKINS_HOME in bytes")
                 .create();
         jobUsageGauge = Gauge.build()
                 .namespace(ConfigurationUtils.getNamespace())
                 .subsystem(ConfigurationUtils.getSubSystem())
-                .name("job_usage")
+                .name("job_usage_bytes")
                 .labelNames(jobLabels)
                 .help("Amount of disk usage (bytes) for each job in Jenkins")
                 .create();

--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.prometheus;
+
+import com.cloudbees.simplediskusage.QuickDiskUsagePlugin;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Gauge;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.prometheus.util.ConfigurationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DiskUsageCollector extends Collector {
+
+    private static final Logger logger = LoggerFactory.getLogger(DiskUsageCollector.class);
+    private Jenkins jenkins;
+    private Gauge directoryUsageGauge;
+    private Gauge jobUsageGauge;
+    private static final String[] directoryLabels = {"directory"};
+    private static final String[] jobLabels = {"jobName", "url"};
+
+    public DiskUsageCollector() {
+        jenkins = Jenkins.get();
+        directoryUsageGauge = Gauge.build()
+                .namespace(ConfigurationUtils.getNamespace())
+                .subsystem(ConfigurationUtils.getSubSystem())
+                .name("disk_usage")
+                .labelNames(directoryLabels)
+                .help("Disk usage of first level folder in JENKINS_HOME in bytes")
+                .create();
+        jobUsageGauge = Gauge.build()
+                .namespace(ConfigurationUtils.getNamespace())
+                .subsystem(ConfigurationUtils.getSubSystem())
+                .name("job_usage")
+                .labelNames(jobLabels)
+                .help("Amount of disk usage (bytes) for each job in Jenkins")
+                .create();
+    }
+
+    @Override
+    @Nonnull
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> samples = new ArrayList<>();
+        try {
+            QuickDiskUsagePlugin diskUsagePlugin = jenkins.getPlugin(QuickDiskUsagePlugin.class);
+            if (diskUsagePlugin == null) {
+                logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not installed.");
+                return samples;
+            }
+            diskUsagePlugin.getDirectoriesUsages().forEach(
+                    i -> directoryUsageGauge.labels(i.getDisplayName())
+                            .set(i.getUsage() * 1024)
+            );
+            samples.addAll(directoryUsageGauge.collect());
+
+            diskUsagePlugin.getJobsUsages().forEach(
+                    i -> jobUsageGauge.labels(i.getFullName(), i.getUrl())
+                            .set(i.getUsage() * 1024)
+            );
+            samples.addAll(jobUsageGauge.collect());
+        } catch (IOException e) {
+            logger.warn("Cannot get disk usage data due to an unexpected error", e);
+        }
+        return samples;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollector.java
@@ -13,7 +13,7 @@ public class JenkinsStatusCollector extends Collector {
 
     @Override
     public List<MetricFamilySamples> collect() {
-        String subsystem = "jenkins";
+        String subsystem = ConfigurationUtils.getSubSystem();
         String namespace = ConfigurationUtils.getNamespace();
         List<MetricFamilySamples> samples = new ArrayList<>();
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -53,7 +53,7 @@ public class JobCollector extends Collector {
         List<MetricFamilySamples> samples = new ArrayList<>();
         List<Job> jobs = new ArrayList<>();
         String fullname = "builds";
-        String subsystem = "jenkins";
+        String subsystem = ConfigurationUtils.getSubSystem();
         String jobAttribute = PrometheusConfiguration.get().getJobAttributeName();
         String[] labelNameArray = {jobAttribute, "repo"};
         String[] labelStageNameArray = {jobAttribute, "repo", "stage"};

--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -5,6 +5,7 @@ import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.prometheus.client.hotspot.DefaultExports;
 import jenkins.metrics.api.Metrics;
+import org.jenkinsci.plugins.prometheus.DiskUsageCollector;
 import org.jenkinsci.plugins.prometheus.JenkinsStatusCollector;
 import org.jenkinsci.plugins.prometheus.JobCollector;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ public class DefaultPrometheusMetrics implements PrometheusMetrics {
         collectorRegistry.register(new JobCollector());
         collectorRegistry.register(new JenkinsStatusCollector());
         collectorRegistry.register(new DropwizardExports(Metrics.metricRegistry()));
+        collectorRegistry.register(new DiskUsageCollector());
         DefaultExports.initialize();
 
         this.collectorRegistry = collectorRegistry;

--- a/src/main/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtils.java
@@ -13,4 +13,8 @@ public class ConfigurationUtils {
         }
         return namespace;
     }
+
+    public static String getSubSystem() {
+        return "jenkins";
+    }
 }


### PR DESCRIPTION
Adding these new metrics

```
# HELP default_jenkins_disk_usage Disk usage of first level folder in JENKINS_HOME in bytes
# TYPE default_jenkins_disk_usage gauge
default_jenkins_disk_usage{directory="java.io.tmpdir",} 8.5937152E7
default_jenkins_disk_usage{directory="JENKINS_HOME",} 3.7107712E7
default_jenkins_disk_usage{directory="JENKINS_HOME/secrets",} 3072.0
default_jenkins_disk_usage{directory="JENKINS_HOME/users",} 0.0
default_jenkins_disk_usage{directory="JENKINS_HOME/jobs",} 0.0
default_jenkins_disk_usage{directory="JENKINS_HOME/nodes",} 0.0
default_jenkins_disk_usage{directory="JENKINS_HOME/plugins",} 3.7100544E7
# HELP default_jenkins_job_usage Amount of disk usage (bytes) for each job in Jenkins
# TYPE default_jenkins_job_usage gauge
default_jenkins_job_usage{jobName="Folder_1/job-1",url="job/Folder_1/job/job-1/",} 282000.0
```

@markyjackson-taulia