### PR TITLE
Bugfix/process disabled builds rename config desc

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -57,7 +57,7 @@ public class JobCollector extends Collector {
         String jobAttribute = PrometheusConfiguration.get().getJobAttributeName();
         String[] labelNameArray = {jobAttribute, "repo"};
         String[] labelStageNameArray = {jobAttribute, "repo", "stage"};
-        boolean ignoreDisabledJobs = PrometheusConfiguration.get().isProcessingDisabledBuilds();
+        boolean processDisabledJobs = PrometheusConfiguration.get().isProcessingDisabledBuilds();
         boolean ignoreBuildMetrics =
                 !PrometheusConfiguration.get().isCountAbortedBuilds() &&
                         !PrometheusConfiguration.get().isCountFailedBuilds() &&
@@ -159,7 +159,7 @@ public class JobCollector extends Collector {
         Jobs.forEachJob(job -> {
             logger.debug("Determining if we are already appending metrics for job [{}]", job.getName());
 
-            if (!job.isBuildable() && ignoreDisabledJobs) {
+            if (!job.isBuildable() && processDisabledJobs) {
                 logger.debug("job [{}] is disabled", job.getFullName());
                 return;
             }

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -31,7 +31,7 @@
     <f:entry title="${%Fetch the test results of builds}" field="fetchTestResults">
       <f:checkbox/>
     </f:entry>
-    <f:entry title="${%Ignore disabled jobs}" field="processingDisabledBuilds">
+    <f:entry title="${%Process disabled jobs}" field="processingDisabledBuilds">
       <f:checkbox/>
     </f:entry>
     <f:entry title="${%Job attribute name}" field="jobAttributeName">

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-path.jelly
@@ -52,7 +52,7 @@
   </div>
   <div>
     <p>
-      Ignore disabled jobs.
+      Process disabled jobs.
     </p>
   </div>
     <div>


### PR DESCRIPTION
### Changes proposed
- The current description in the Jenkins UI is misleading, because:
If "Ignore disabled jobs" is set to "true" I would expect that no disabled jobs are processed. However this description matches to the underlying variable "processingDisabledBuilds" which means exactly the opposite.


### Checklist

- [ ] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
