### PR TITLE
Fix bug with traversal.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/util/FlowNodes.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/util/FlowNodes.java
@@ -100,11 +100,9 @@ public class FlowNodes {
                 continue;
             }
             for (final FlowNode next : parents) {
-                final Integer nextId = getNodeId(next);
-                if (visited.contains(nextId)) {
+                if (visited.contains(getNodeId(next))) {
                     return false;
                 }
-                visited.add(nextId);
                 queue.add(next);
             }
         }


### PR DESCRIPTION
When the switch to iterative BFS was made, adding to the queue of nodes
to visit also added to the set of visited nodes. This is wrong. Queued nodes
aren't visited yet.

Without this fix, there is a possibility of missing metrics.

### Notify

@markyjackson-taulia
