### PR TITLE
override `getNormalLoggingLevel` to set log `Level.Fine`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/PrometheusAsyncWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/PrometheusAsyncWorker.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 @Extension
 public class PrometheusAsyncWorker extends AsyncPeriodicWork {
@@ -39,6 +40,11 @@ public class PrometheusAsyncWorker extends AsyncPeriodicWork {
         logger.debug("Collecting prometheus metrics");
         prometheusMetrics.collectMetrics();
         logger.debug("Prometheus metrics collected successfully");
+    }
+    
+    @Override
+    protected Level getNormalLoggingLevel() {
+        return Level.FINE;
     }
 
 }


### PR DESCRIPTION
Fixes noisy log

removes the `Started prometheus_async_worker` and `Finished prometheus_async_worker` from the standard out log. It leads to a lengthly jenkins.log

### Changes proposed

- override `getNormalLoggingLevel` to set log `Level.Fine`

### Checklist

- [ ] Includes tests covering the new functionality?
- [X] Ready for review
- [X] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
