### PR TITLE
Replace System Rules with System Lambda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <gson.version>2.8.6</gson.version>
     <JUnitParams.version>1.1.1</JUnitParams.version>
     <httpcore.version>4.4.13</httpcore.version>
-    <system-rules.version>1.19.0</system-rules.version>
+    <system-lambda.version>1.1.0</system-lambda.version>
     <assertj-core.version>3.14.0</assertj-core.version>
     <slf4j.version>1.7.26</slf4j.version>
   </properties>
@@ -194,8 +194,8 @@
     </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>${system-rules.version}</version>
+      <artifactId>system-lambda</artifactId>
+      <version>${system-lambda.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
@@ -5,9 +5,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import net.sf.json.JSONObject;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mockito;
@@ -15,15 +13,13 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(JUnitParamsRunner.class)
 public class PrometheusConfigurationTest {
-
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private PrometheusConfiguration configuration;
 
@@ -88,15 +84,15 @@ public class PrometheusConfigurationTest {
     }
 
     @Test
-    public void shouldSetValueFromEnv() {
+    public void shouldSetValueFromEnv() throws Exception{
         // given
         Mockito.doCallRealMethod().when(configuration).setCollectingMetricsPeriodInSeconds(any());
         Mockito.when(configuration.getCollectingMetricsPeriodInSeconds()).thenCallRealMethod();
-        environmentVariables.set(PrometheusConfiguration.COLLECTING_METRICS_PERIOD_IN_SECONDS, "1000");
         Long metricCollectorPeriod = null;
 
         // when
-        configuration.setCollectingMetricsPeriodInSeconds(metricCollectorPeriod);
+        withEnvironmentVariable(PrometheusConfiguration.COLLECTING_METRICS_PERIOD_IN_SECONDS, "1000")
+                .execute(() -> configuration.setCollectingMetricsPeriodInSeconds(metricCollectorPeriod));
         long actual = configuration.getCollectingMetricsPeriodInSeconds();
 
         // then
@@ -105,15 +101,15 @@ public class PrometheusConfigurationTest {
 
     @Test
     @Parameters(method = "wrongMetricCollectorPeriodsProvider")
-    public void shouldSetDefaultValueWhenEnvCannotBeConvertedToLongORNegativeValue(String wrongValue) {
+    public void shouldSetDefaultValueWhenEnvCannotBeConvertedToLongORNegativeValue(String wrongValue) throws Exception {
         // given
         Mockito.doCallRealMethod().when(configuration).setCollectingMetricsPeriodInSeconds(any());
         Mockito.when(configuration.getCollectingMetricsPeriodInSeconds()).thenCallRealMethod();
-        environmentVariables.set(PrometheusConfiguration.COLLECTING_METRICS_PERIOD_IN_SECONDS, wrongValue);
         Long metricCollectorPeriod = null;
 
         // when
-        configuration.setCollectingMetricsPeriodInSeconds(metricCollectorPeriod);
+        withEnvironmentVariable(PrometheusConfiguration.COLLECTING_METRICS_PERIOD_IN_SECONDS, wrongValue)
+                .execute(() -> configuration.setCollectingMetricsPeriodInSeconds(metricCollectorPeriod));
         long actual = configuration.getCollectingMetricsPeriodInSeconds();
 
         // then


### PR DESCRIPTION
System Lambda has minimal impact. It only sets the environment variable
for the statement that reads it. In addition it is independent of the
testing framework. E.g. it can still be used if JUnit 4 is replace with
JUnit Jupiter or another framework.

### Checklist

- [x] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
