### PR TITLE
Update pom URL [WEBSITE-406]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>Prometheus metrics plugin</name>
   <description>Expose Jenkins metrics in prometheus format</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Prometheus+Plugin</url>
+  <url>https://github.com/jenkinsci/prometheus-plugin</url>
   <inceptionYear>2016</inceptionYear>
 
   <properties>


### PR DESCRIPTION
Load documentation from Github instead of the wiki.

Related tickets:
https://issues.jenkins-ci.org/browse/WEBSITE-406
https://issues.jenkins-ci.org/browse/JENKINS-59172

More info: https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/

### Checklist

- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
