### PR TITLE
Make prometheus plugin open for contributions from other plugins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.prometheus.service;
 
+import hudson.ExtensionList;
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.common.TextFormat;
@@ -28,6 +30,10 @@ public class DefaultPrometheusMetrics implements PrometheusMetrics {
         collectorRegistry.register(new JenkinsStatusCollector());
         collectorRegistry.register(new DropwizardExports(Metrics.metricRegistry()));
         collectorRegistry.register(new DiskUsageCollector());
+
+        // other collectors from other plugins
+        ExtensionList.lookup(Collector.class).forEach( c -> collectorRegistry.register(c));
+
         DefaultExports.initialize();
 
         this.collectorRegistry = collectorRegistry;


### PR DESCRIPTION
Fixes #174 

### Changes proposed

Make the plugin open for extensions from other plugins.

### Checklist

- [-] Includes tests covering the new functionality? Not sure how to test without creating another plugin
- [/] Ready for review
- [/] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
