### PR TITLE
Fix successful stage detection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.prometheus;
 
 import com.cloudbees.workflow.rest.external.StageNodeExt;
+import com.cloudbees.workflow.rest.external.StatusExt;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -380,7 +381,7 @@ public class JobCollector extends Collector {
         String stageName = stage.getName();
         String[] labelValueArray = {jobName, repoName, stageName};
 
-        if (stage.getStatus().ordinal() < 2) {
+        if (stage.getStatus() == StatusExt.SUCCESS || stage.getStatus() == StatusExt.UNSTABLE) {
             logger.debug("getting duration for stage[{}] in run [{}] from job [{}]", stage.getName(), run.getNumber(), job.getName());
             long duration = stage.getDurationMillis();
             logger.debug("duration was [{}] for stage[{}] in run [{}] from job [{}]", duration, stage.getName(), run.getNumber(), job.getName());


### PR DESCRIPTION
While using #177 in our production instance we found a problem with the stage metrics, only aborted stages are reflected in the metrics. This happened because the stage object use a different status enum than the jobs or runs.

### Changes proposed

- Use explicit comparison for stage results with the correct enum values

### Checklist

- [ ] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
