### PR TITLE
chore(ci): change to use Azure Container Instances for build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useAci: true)


### PR DESCRIPTION
Fixes [#184(comment)](https://github.com/jenkinsci/prometheus-plugin/pull/184#issuecomment-726350540)

Up to you if you think running the builds of this plugin in containers brings a benefit, but it should prevent errors like `No space left on device`

### Changes proposed

- use Azure Container Instances for build

### Checklist

- [ ] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
