### PR TITLE
Fix null pointer exception when gathering job parameters (JENKINS-63998)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -307,7 +307,7 @@ public class JobCollector extends Collector {
             logger.debug("getting metrics for run [{}] from job [{}]", run.getNumber(), job.getName());
             if (Runs.includeBuildInMetrics(run)) {
                 logger.debug("getting build info for run [{}] from job [{}]", run.getNumber(), job.getName());
-                String params = Runs.getBuildParameters(run).entrySet().stream().map(e -> "" + e.getKey() + "=" + e.getValue().toString()).collect(Collectors.joining(";"));
+                String params = Runs.getBuildParameters(run).entrySet().stream().map(e -> "" + e.getKey() + "=" + String.valueOf(e.getValue())).collect(Collectors.joining(";"));
                 String resultString = "UNDEFINED";
                 runResult = run.getResult();
                 if (runResult != null) {


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-63998. This issue happens, because during gathering of the metrics a NullPointerException occurs when retreiving the job parameters. This exception is not handled, so the thread gathering the metrics is terminated without providing metrics.

Note: This is my first pull-request. If there are any formal issues with it, please tell me.

### Changes proposed

- Change the way the job parameter string is build, so that a job parameter with a "null" value does not cause a NullPointerException. This seems e.g. to happen for parameterized jobs with a SVN Tags parameter. 

### Checklist

- [ ] Includes tests covering the new functionality?
- [X] Ready for review
- [X] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
