### PR TITLE
Issue 185 - Names & Labels for jenkins_node_*_builds Metrics

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.prometheus.DiskUsageCollector;
 import org.jenkinsci.plugins.prometheus.ExecutorCollector;
 import org.jenkinsci.plugins.prometheus.JenkinsStatusCollector;
 import org.jenkinsci.plugins.prometheus.JobCollector;
+import org.jenkinsci.plugins.prometheus.util.MetricsFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,21 +54,9 @@ public class DefaultPrometheusMetrics implements PrometheusMetrics {
     public void collectMetrics() {
         try (StringWriter buffer = new StringWriter()) {
             TextFormat.write004(buffer, collectorRegistry.metricFamilySamples());
-            cachedMetrics.set(formatMetrics(buffer.toString()));
+            cachedMetrics.set(MetricsFormatter.formatMetrics(buffer.toString()));
         } catch (IOException e) {
             logger.debug("Unable to collect metrics");
         }
-    }
-
-    private String formatMetrics(String formatString) {
-        //node specific build counts
-        formatString = formatString.replaceAll("jenkins_node_builds_count (.*)", "jenkins_node_builds_count{node=\"master\"} $1");
-        formatString = formatString.replaceAll("jenkins_node_(.*)_builds_count (.*)", "jenkins_node_builds_count{node=\"$1\"} $2");
-
-        //node specific histograms
-        formatString = formatString.replaceAll("jenkins_node_builds\\{(.*)} (.*)", "jenkins_node_builds{node=\"master\", $1} $2");
-        formatString = formatString.replaceAll("jenkins_node_(.*)_builds\\{(.*)} (.*)", "jenkins_node_builds{node=\"$1\", $2} $3");
-
-        return formatString;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -60,7 +60,7 @@ public class DefaultPrometheusMetrics implements PrometheusMetrics {
     }
 
     private String formatMetrics(String formatString) {
-        formatString = formatString.replaceAll("jenkins_node_(.*)_build_count (.*)", "jenkis_node_build_count{node=\"master\" $1");
+        formatString = formatString.replaceAll("jenkins_node_build_count (.*)", "jenkis_node_build_count{node=\"master\" $1");
         return formatString.replaceAll("jenkins_node_(.*)_build_count (.*)", "jenkins_node_build_count{node=\"$1\"} $2");
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DefaultPrometheusMetrics implements PrometheusMetrics {
 
@@ -51,9 +53,14 @@ public class DefaultPrometheusMetrics implements PrometheusMetrics {
     public void collectMetrics() {
         try (StringWriter buffer = new StringWriter()) {
             TextFormat.write004(buffer, collectorRegistry.metricFamilySamples());
-            cachedMetrics.set(buffer.toString());
+            cachedMetrics.set(formatMetrics(buffer.toString()));
         } catch (IOException e) {
             logger.debug("Unable to collect metrics");
         }
+    }
+
+    private String formatMetrics(String formatString) {
+        formatString = formatString.replaceAll("jenkins_node_(.*)_build_count (.*)", "jenkis_node_build_count{node=\"master\" $1");
+        return formatString.replaceAll("jenkins_node_(.*)_build_count (.*)", "jenkins_node_build_count{node=\"$1\"} $2");
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -18,8 +18,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class DefaultPrometheusMetrics implements PrometheusMetrics {
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/service/DefaultPrometheusMetrics.java
@@ -60,7 +60,14 @@ public class DefaultPrometheusMetrics implements PrometheusMetrics {
     }
 
     private String formatMetrics(String formatString) {
-        formatString = formatString.replaceAll("jenkins_node_build_count (.*)", "jenkis_node_build_count{node=\"master\" $1");
-        return formatString.replaceAll("jenkins_node_(.*)_build_count (.*)", "jenkins_node_build_count{node=\"$1\"} $2");
+        //node specific build counts
+        formatString = formatString.replaceAll("jenkins_node_builds_count (.*)", "jenkins_node_builds_count{node=\"master\"} $1");
+        formatString = formatString.replaceAll("jenkins_node_(.*)_builds_count (.*)", "jenkins_node_builds_count{node=\"$1\"} $2");
+
+        //node specific histograms
+        formatString = formatString.replaceAll("jenkins_node_builds\\{(.*)} (.*)", "jenkins_node_builds{node=\"master\", $1} $2");
+        formatString = formatString.replaceAll("jenkins_node_(.*)_builds\\{(.*)} (.*)", "jenkins_node_builds{node=\"$1\", $2} $3");
+
+        return formatString;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/prometheus/util/MetricsFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/util/MetricsFormatter.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.prometheus.util;
+
+public class MetricsFormatter {
+
+    public static String formatMetrics(String formatString) {
+        //node specific build counts
+        formatString = formatString.replaceAll("jenkins_node_builds_count (.*)", "jenkins_node_builds_count{node=\"master\"} $1");
+        formatString = formatString.replaceAll("jenkins_node_(.*)_builds_count (.*)", "jenkins_node_builds_count{node=\"$1\"} $2");
+
+        //node specific histograms
+        formatString = formatString.replaceAll("jenkins_node_builds\\{(.*)} (.*)", "jenkins_node_builds{node=\"master\",$1} $2");
+        formatString = formatString.replaceAll("jenkins_node_(.*)_builds\\{(.*)} (.*)", "jenkins_node_builds{node=\"$1\",$2} $3");
+
+        return formatString;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/util/MetricsFormatterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/util/MetricsFormatterTest.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.prometheus.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricsFormatterTest {
+
+    private final String inString = "jenkins_node_builds{quantile=\"0.5\",} 0.091670452\n" +
+            "jenkins_node_builds{quantile=\"0.75\",} 0.091670452\n" +
+            "jenkins_node_builds{quantile=\"0.95\",} 0.091670452\n" +
+            "jenkins_node_builds{quantile=\"0.98\",} 0.091670452\n" +
+            "jenkins_node_builds{quantile=\"0.99\",} 0.091670452\n" +
+            "jenkins_node_builds{quantile=\"0.999\",} 0.091670452\n" +
+            "jenkins_node_my_node_1_builds{quantile=\"0.99\",} 0.091670452\n" +
+            "jenkins_node_my_node_4_builds{quantile=\"0.999\",} 0.091670452\n" +
+            "jenkins_node_builds_count 28458.0\n" +
+            "jenkins_node_my_node_1_builds_count 12345";
+
+    @Test
+    public void master_node_count_format() {
+        String formatString = MetricsFormatter.formatMetrics(inString);
+        //master node count
+        Assert.assertFalse(formatString.contains("jenkins_node_builds_count 28458.0\n"));
+        Assert.assertTrue(formatString.contains("jenkins_node_builds_count{node=\"master\"} 28458.0\n"));
+    }
+
+    @Test
+    public void master_node_histogram_format() {
+        String formatString = MetricsFormatter.formatMetrics(inString);
+        //master node histogram
+        Assert.assertFalse(formatString.contains("jenkins_node_builds{quantile=\"0.999\",} 0.091670452\n"));
+        Assert.assertTrue(formatString.contains("jenkins_node_builds{node=\"master\",quantile=\"0.999\",} 0.091670452\n"));
+    }
+
+    @Test
+    public void named_node_count_format() {
+        String formatString = MetricsFormatter.formatMetrics(inString);
+        //named node count
+        Assert.assertFalse(formatString.contains("jenkins_node_my_node_1_builds_count"));
+        Assert.assertTrue(formatString.contains("jenkins_node_builds_count{node=\"my_node_1\"} 12345"));
+    }
+
+    @Test
+    public void named_node_histogram_format() {
+        String formatString = MetricsFormatter.formatMetrics(inString);
+        //named node histogram
+        Assert.assertFalse(formatString.contains("jenkins_node_my_node_4_builds{quantile=\"0.999\",} 0.091670452\n"));
+        Assert.assertTrue(formatString.contains("jenkins_node_builds{node=\"my_node_4\",quantile=\"0.999\",} 0.091670452\n"));
+    }
+}


### PR DESCRIPTION
Fixes #185 

Heads up - I took a quick look at this and it seems more difficult than I anticipated.

The build node metrics are derived from Dropwizard + jenkins metrics plugin which means we'll either have to:
A) Pull the metric timer out of the jenkins plugin and build a custom metric for it jenkins.node._XXX.builds
B) Intercept the response before it's sent and rewrite those specific endpoints

I went with option B here. It's a bit cleaner.

### Changes proposed
- Regex Match the specific metric names which include node name
- Standardize metric names and use node name as label
- Add master label to non-node specific metrics

### Checklist

- [/ ] Includes tests covering the new functionality?
- [/ ] Ready for review
- [/ ] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
