### PR TITLE
ISSUE-204 - last build metrics don't have stages breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ You should usually open a pull request in the following situations:
 Submit trivial fixes (for example, a typo, a broken link or an obvious error)
 Start work on a contribution that was already asked for, or that you’ve already discussed, in an issue
 
+### Testing your code
+To run unit tests, use the `test` maven goal, or
+```shell
+mvn test
+```
+
+The automated pipeline also runs static analysis, to run it locally, use the `spotbugs:check` target, or
+```shell
+mvn spotbugs:check
+```
+
 ### Forking a repository
 Fork the repository and clone it locally. Connect your local to the original “upstream” repository by adding it as a remote. Pull in changes from “upstream” often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely.
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -33,7 +33,7 @@ public class JobCollector extends Collector {
     private Counter jobFailedCount;
     private Gauge jobHealthScore;
 
-    private class BuildMetrics {
+    private static class BuildMetrics {
 
         public Gauge jobBuildResultOrdinal;
         public Gauge jobBuildResult;


### PR DESCRIPTION
Fixes #204 

### Changes proposed

- Add processing of the last completed job, which, we also break down to stages.
- Took the opportunity to unify code between processing a generic run when iterating everything, and when processing the last completed one.
- Added a subclass to handle Run specific metric collectors to make it easier to add more metrics in the future and reduce code duplication

### Checklist

- [ ] Includes tests covering the new functionality?
- [V] Ready for review
- [V] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
