### PR TITLE
Fix excessive metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <inceptionYear>2016</inceptionYear>
 
   <properties>
-    <jenkins.version>2.204.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
     <prometheus.simpleClientJava.version>0.8.0</prometheus.simpleClientJava.version>
     <workflow.api.version>2.41</workflow.api.version>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -50,53 +50,53 @@ public class JobCollector extends Collector {
             this.buildPrefix = buildPrefix;
         }
 
-        public void initCollectors(String fullname, String subsystem, String namespace, String[] labelBaseNameArray, String[] labelStageNameArray) {
+        public void initCollectors(String fullname, String subsystem, String namespace, String[] labelNameArray, String[] labelStageNameArray) {
             this.jobBuildResultOrdinal = Gauge.build()
                     .name(fullname + this.buildPrefix +"_build_result_ordinal")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Build status of a job.")
                     .create();
 
             this.jobBuildResult = Gauge.build()
                     .name(fullname + this.buildPrefix +"_build_result")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Build status of a job as a boolean (0 or 1)")
                     .create();
 
             this.jobBuildDuration = Gauge.build()
                     .name(fullname + this.buildPrefix +"_build_duration_milliseconds")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Build times in milliseconds of last build")
                     .create();
 
             this.jobBuildStartMillis = Gauge.build()
                     .name(fullname + this.buildPrefix +"_build_start_time_milliseconds")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Last build start timestamp in milliseconds")
                     .create();
 
             this.jobBuildTestsTotal = Gauge.build()
                     .name(fullname + this.buildPrefix +"_build_tests_total")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Number of total tests during the last build")
                     .create();
 
             this.jobBuildTestsSkipped = Gauge.build()
                     .name(fullname + "_last_build_tests_skipped")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Number of skipped tests during the last build")
                     .create();
 
             this.jobBuildTestsFailing = Gauge.build()
                     .name(fullname + this.buildPrefix +"_build_tests_failing")
                     .subsystem(subsystem).namespace(namespace)
-                    .labelNames(labelBaseNameArray)
+                    .labelNames(labelNameArray)
                     .help("Number of failing tests during the last build")
                     .create();
 
@@ -122,12 +122,22 @@ public class JobCollector extends Collector {
         String fullname = "builds";
         String subsystem = ConfigurationUtils.getSubSystem();
         String jobAttribute = PrometheusConfiguration.get().getJobAttributeName();
+
         String[] labelBaseNameArray = {jobAttribute, "repo"};
-        String[] labelBuildNameArray = Arrays.copyOf(labelBaseNameArray, labelBaseNameArray.length + 2);
-        labelBuildNameArray[labelBaseNameArray.length] = "parameters";
-        labelBuildNameArray[labelBaseNameArray.length + 1] = "status";
+
+        String[] labelNameArray = labelBaseNameArray;
+        if( PrometheusConfiguration.get().isAppendParamLabel() ){
+            labelNameArray = Arrays.copyOf(labelNameArray, labelNameArray.length + 1);
+            labelNameArray[labelNameArray.length - 1] = "parameters";
+        }
+        if( PrometheusConfiguration.get().isAppendStatusLabel() ){
+            labelNameArray = Arrays.copyOf(labelNameArray, labelNameArray.length + 1);
+            labelNameArray[labelNameArray.length - 1] = "status";
+        }
+        
         String[] labelStageNameArray = Arrays.copyOf(labelBaseNameArray, labelBaseNameArray.length + 1);
         labelStageNameArray[labelBaseNameArray.length] = "stage";
+
         boolean processDisabledJobs = PrometheusConfiguration.get().isProcessingDisabledBuilds();
         boolean ignoreBuildMetrics =
                 !PrometheusConfiguration.get().isCountAbortedBuilds() &&
@@ -140,27 +150,32 @@ public class JobCollector extends Collector {
             return samples;
         }
 
+        // Below three metrics use labaelNameArray which might include the optional labels
+        // of "parameters" or "status"
         summary = Summary.build()
                 .name(fullname + "_duration_milliseconds_summary")
                 .subsystem(subsystem).namespace(namespace)
-                .labelNames(labelBaseNameArray)
+                .labelNames(labelNameArray)
                 .help("Summary of Jenkins build times in milliseconds by Job")
                 .create();
 
         jobSuccessCount = Counter.build()
                 .name(fullname + "_success_build_count")
                 .subsystem(subsystem).namespace(namespace)
-                .labelNames(labelBaseNameArray)
+                .labelNames(labelNameArray)
                 .help("Successful build count")
                 .create();
 
         jobFailedCount = Counter.build()
                 .name(fullname + "_failed_build_count")
                 .subsystem(subsystem).namespace(namespace)
-                .labelNames(labelBaseNameArray)
+                .labelNames(labelNameArray)
                 .help("Failed build count")
                 .create();
 
+        // This metric uses "base" labels as it is just the health score reported
+        // by the job object and the optional labels params and status don't make much
+        // sense in this context.
         jobHealthScore = Gauge.build()
                 .name(fullname + "_health_score")
                 .subsystem(subsystem).namespace(namespace)
@@ -168,7 +183,8 @@ public class JobCollector extends Collector {
                 .help("Health score of a job")
                 .create();
 
-        lastBuildMetrics.initCollectors(fullname, subsystem, namespace, labelBuildNameArray, labelStageNameArray);
+        // The lastBuildMetrics are initialized with the "base" labels
+        lastBuildMetrics.initCollectors(fullname, subsystem, namespace, labelBaseNameArray, labelStageNameArray);
 
         Jobs.forEachJob(job -> {
             try{
@@ -179,8 +195,8 @@ public class JobCollector extends Collector {
                 logger.debug("Collecting metrics for job [{}]", job.getFullName());
                 appendJobMetrics(job);
             }
-            catch( Exception e){
-                logger.debug("Caught error when processing job [{}] error [{}]", job.getFullName(), e);
+            catch( Exception e ){
+                logger.warn("Caught error when processing job [{}] error: ", job.getFullName(), e);
             }
             
         });
@@ -220,7 +236,7 @@ public class JobCollector extends Collector {
         if (repoName == null) {
             repoName = "NA";
         }
-        String[] labelValueArray = {job.getFullName(), repoName};
+        String[] baseLabelValueArray = {job.getFullName(), repoName };
 
         Run lastBuild = job.getLastBuild();
         // Never built
@@ -229,39 +245,41 @@ public class JobCollector extends Collector {
             return;
         }
 
-        long duration;
         int score = job.getBuildHealth().getScore();
-        jobHealthScore.labels(labelValueArray).set(score);
+        jobHealthScore.labels(baseLabelValueArray).set(score);
 
-        Result runResult;
-        String resultString = "UNDEFINED";
-        runResult = lastBuild.getResult();
-        if (null != runResult) {
-            resultString = runResult.toString();
-        }
+        processRun(job, lastBuild, baseLabelValueArray, lastBuildMetrics);
 
-        String params = Runs.getBuildParameters(lastBuild).entrySet().stream().map(e -> "" + e.getKey() + "=" + String.valueOf(e.getValue())).collect(Collectors.joining(";"));
-        String[] buildLabelValueArray = {job.getFullName(), repoName, params, lastBuild.isBuilding() ? "RUNNING" : resultString};
-        processRun(job, lastBuild, buildLabelValueArray, lastBuildMetrics);
+        boolean isAppendParamLabel = PrometheusConfiguration.get().isAppendParamLabel();
+        boolean isAppendStatusLabel = PrometheusConfiguration.get().isAppendStatusLabel();
 
         Run run = lastBuild;
         while (run != null) {
             logger.debug("getting metrics for run [{}] from job [{}]", run.getNumber(), job.getName());
             if (Runs.includeBuildInMetrics(run)) {
                 logger.debug("getting build info for run [{}] from job [{}]", run.getNumber(), job.getName());
-                params = Runs.getBuildParameters(run).entrySet().stream().map(e -> "" + e.getKey() + "=" + String.valueOf(e.getValue())).collect(Collectors.joining(";"));
-                resultString = "UNDEFINED";
-                runResult = run.getResult();
-                if (runResult != null) {
-                    resultString = runResult.toString();
-                }
+                
+                Result runResult = run.getResult();
+                String[] labelValueArray = baseLabelValueArray;
 
-                duration = run.getDuration();
+                if( isAppendParamLabel ){
+                    String params = Runs.getBuildParameters(run).entrySet().stream().map(e -> "" + e.getKey() + "=" + String.valueOf(e.getValue())).collect(Collectors.joining(";"));
+                    labelValueArray = Arrays.copyOf(labelValueArray, labelValueArray.length + 1);
+                    labelValueArray[labelValueArray.length - 1] = params;
+                }
+                if( isAppendStatusLabel ){
+                    String resultString = "UNDEFINED";
+                    if (runResult != null) {
+                        resultString = runResult.toString();
+                    }
+                    labelValueArray = Arrays.copyOf(labelValueArray, labelValueArray.length + 1);
+                    labelValueArray[labelValueArray.length - 1] =  run.isBuilding() ? "RUNNING" : resultString;
+                }
+                
+                long duration = run.getDuration();
                 if (!run.isBuilding()) {
                     summary.labels(labelValueArray).observe(duration);
                 }
-
-                runResult = run.getResult();
 
                 if (runResult != null && !run.isBuilding()) {
                     if (runResult.ordinal == 0 || runResult.ordinal == 1) {

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -49,6 +49,9 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     private boolean processingDisabledBuilds = false;
 
+    private boolean appendParamLabel = false;
+    private boolean appendStatusLabel = false;
+
     public PrometheusConfiguration() {
         load();
         setPath(urlName);
@@ -75,6 +78,8 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         collectingMetricsPeriodInSeconds = validateProcessingMetricsPeriodInSeconds(json);
 
         processingDisabledBuilds = json.getBoolean("processingDisabledBuilds");
+        appendParamLabel = json.getBoolean("appendParamLabel");
+        appendStatusLabel = json.getBoolean("appendStatusLabel");
 
         save();
         return super.configure(req, json);
@@ -195,6 +200,24 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     public void setProcessingDisabledBuilds(boolean processingDisabledBuilds) {
         this.processingDisabledBuilds = processingDisabledBuilds;
+        save();
+    }
+
+    public boolean isAppendParamLabel() {
+        return appendParamLabel;
+    }
+
+    public void setAppendParamLabel(boolean appendParamLabel) {
+        this.appendParamLabel = appendParamLabel;
+        save();
+    }
+
+    public boolean isAppendStatusLabel() {
+        return appendStatusLabel;
+    }
+
+    public void setAppendStatusLabel(boolean appendStatusLabel) {
+        this.appendStatusLabel = appendStatusLabel;
         save();
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -31,6 +31,12 @@
     <f:entry title="${%Fetch the test results of builds}" field="fetchTestResults">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Add build parameter label to metrics}" field="appendParamLabel">
+      <f:checkbox/>
+    </f:entry>
+    <f:entry title="${%Add build status label to metrics}" field="appendStatusLabel">
+      <f:checkbox/>
+    </f:entry>
     <f:entry title="${%Process disabled jobs}" field="processingDisabledBuilds">
       <f:checkbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-appendParamLabel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-appendParamLabel.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      Add a "parameters" label to the duration_milliseconds_summary, success_build_count, and
+      failed_build_count metrics which contains the build parameters.  This would allow calculation
+      of the average build duration based on build parameters.
+    </p>
+  </div>
+  <div class="warning">
+    <p>
+      Warning! If the cardinality of your build parameters is high, this will create
+      a large number of metrics.  This can result in poor jenkins and prometheus
+      performance.
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-appendStatusLabel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-appendStatusLabel.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      Add a "status" ("SUCCESS", "FAILURE", "RUNNING") label to the duration_milliseconds_summary, 
+      success_build_count, and failed_build_count metrics.
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-collectingMetricsPeriodInSeconds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-collectingMetricsPeriodInSeconds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Collecting metrics period in seconds (effectively loaded after restart).
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countAbortedBuilds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countAbortedBuilds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Count the duration of aborted builds.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countFailedBuilds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countFailedBuilds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Count the duration of failed builds.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countNotBuiltBuilds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countNotBuiltBuilds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Count the duration of not-built builds.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countSuccessfulBuilds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countSuccessfulBuilds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Count the duration of successful builds.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countUnstableBuilds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-countUnstableBuilds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Count the duration of unstable builds.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-defaultNamespace.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-defaultNamespace.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      The default namespace (default value is 'default'). Setting this to an empty value will return the build values as Jenkins metrics.
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-fetchTestResults.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-fetchTestResults.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Fetch the test results of builds.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-jobAttributeName.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-jobAttributeName.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      The attribute name for job data such as xxx_duration_milliseconds_summary(job_attribute_name="x/y/z") used to be job, but it was a saved word for Prometheus.
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-processingDisabledBuilds.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-processingDisabledBuilds.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Process disabled jobs.
     </p>
   </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-useAuthenticatedEndpoint.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-useAuthenticatedEndpoint.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-      The path where the prometheus metrics should be provided.
+      Enable authentication for the Prometheus endpoint.
     </p>
   </div>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
@@ -129,6 +129,8 @@ public class PrometheusConfigurationTest {
         config.accumulate("countAbortedBuilds", "true");
         config.accumulate("fetchTestResults", "true");
         config.accumulate("processingDisabledBuilds", "false");
+        config.accumulate("appendParamLabel", "false");
+        config.accumulate("appendStatusLabel", "false");
         return config;
     }
 


### PR DESCRIPTION
Fixes #200 
Fixes #206 
May help address #196 

### Changes proposed

- I removed the per build metrics introduced in #177.

- I added two new options - "Add build parameter label to metrics" and "Add build status label to metrics".  The purpose of these is to support the use case described in #176. This would allow a user to calculate the average duration of a job based on build parameters or status.  They were left as optional and default to off as build parameters could have a high cardinality.

Screenshot of the new configuration options with their help text:

![image](https://user-images.githubusercontent.com/5077288/111243170-984ef280-85ce-11eb-9a46-aa83abc3195c.png)

- I bumped up the minimum required jenkins version.  This seemed to be a requirement of recent dependency updates.  I bumped the version up to what the build spat out as the required minimum version when I tried to run the build.

- I fixed the configurations help text. Previously all help text was tied to the "path" variable, but I split it up so each variable had its own link.  e.g. Screenshot of old: 
![image](https://user-images.githubusercontent.com/5077288/111242784-dac3ff80-85cd-11eb-91f9-5ce1cbd637c2.png)

Screenshot of new:

![image](https://user-images.githubusercontent.com/5077288/111243095-6d649e80-85ce-11eb-8bbf-d6a26fcb61df.png)


### Checklist

- [  ] Includes tests covering the new functionality?
- [ x ] Ready for review
- [ x ] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
