### PR TITLE
Make cloudbees-disk-usage-simple optional dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-disk-usage-simple</artifactId>
       <version>${jenkins.diskUsage.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.prometheus;
 
-import com.cloudbees.simplediskusage.QuickDiskUsagePlugin;
 import io.prometheus.client.Collector;
 import io.prometheus.client.Gauge;
 import jenkins.model.Jenkins;
@@ -51,7 +50,7 @@ public class DiskUsageCollector extends Collector {
         List<MetricFamilySamples> samples = new ArrayList<>();
         if(!this.collectDiskUsage) { return samples; }
         try {
-            QuickDiskUsagePlugin diskUsagePlugin = jenkins.getPlugin(QuickDiskUsagePlugin.class);
+        	com.cloudbees.simplediskusage.QuickDiskUsagePlugin diskUsagePlugin = jenkins.getPlugin(com.cloudbees.simplediskusage.QuickDiskUsagePlugin.class);
             if (diskUsagePlugin == null) {
                 logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not installed.");
                 return samples;
@@ -69,6 +68,8 @@ public class DiskUsageCollector extends Collector {
             samples.addAll(jobUsageGauge.collect());
         } catch (IOException e) {
             logger.warn("Cannot get disk usage data due to an unexpected error", e);
+        } catch (java.lang.NoClassDefFoundError e) {
+        	logger.warn("Cannot get disk usage data. Install CloudBees Disk Usage Simple plugin to enable");
         }
         return samples;
     }


### PR DESCRIPTION
Fixes #246 

### Changes proposed

- Make Cloudbees Disk Usage Simple plugin an optional dependency.  I've seen disk performance issues when this plugin is enabled, and for my use case I don't need these metrics.  
- This unfortunately does change existing behavior when initially installing the plugin.  Since the Cloudbees Disk Usage Simple plugin isn't required, Jenkins won't automatically install it by default like it would currently.  I couldn't find a way to specify that an optional dependency should be installed by default.  My intention with this change was to allow disabling the disk usage plugin if it wasn't needed, I didn't really want to change the existing behavior on install.

Before change:
![Screenshot 2021-04-15 195828](https://user-images.githubusercontent.com/5077288/115142142-c2e4fe80-a005-11eb-9387-dd79da046926.png)

After change:
![Screenshot 2021-04-15 200106](https://user-images.githubusercontent.com/5077288/115142151-cc6e6680-a005-11eb-8eea-ccc7a372e0fd.png)

Log message when disk plugin is disabled:
![Screenshot 2021-04-18 045424](https://user-images.githubusercontent.com/5077288/115142153-cf695700-a005-11eb-9b20-d66b6c1fdfde.png)


### Checklist

- [ ] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
