### PR TITLE
Fixes #279: Jenkins job duration metrics filterable by buildable status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -125,7 +125,7 @@ public class JobCollector extends Collector {
         String subsystem = ConfigurationUtils.getSubSystem();
         String jobAttribute = PrometheusConfiguration.get().getJobAttributeName();
 
-        String[] labelBaseNameArray = {jobAttribute, "repo"};
+        String[] labelBaseNameArray = {jobAttribute, "repo", "buildable"};
 
         String[] labelNameArray = labelBaseNameArray;
         if( PrometheusConfiguration.get().isAppendParamLabel() ){
@@ -249,7 +249,7 @@ public class JobCollector extends Collector {
         if (repoName == null) {
             repoName = NOT_AVAILABLE;
         }
-        String[] baseLabelValueArray = {job.getFullName(), repoName };
+        String[] baseLabelValueArray = {job.getFullName(), repoName, String.valueOf( job.isBuildable() ) };
 
         Run lastBuild = job.getLastBuild();
         // Never built


### PR DESCRIPTION
Fixes #279

### Changes proposed

- Enables Jenkins job duration metrics being filterable by build status, thus fixing #279, sorry it took this long to provide the relevant PR
- Note that build fails due to enforcer plugin notifying about some dependencies needing an upgrade; this PR does not cover that error

### Checklist

- [ ] Includes tests covering the new functionality? (PR ended up being fairly trivial)
- [ X ] Ready for review
- [ X ] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
