### PR TITLE
Don't export disk usage metrics of orphaned items

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -4,7 +4,6 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.Gauge;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.prometheus.util.ConfigurationUtils;
-import org.jenkinsci.plugins.prometheus.config.PrometheusConfiguration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,65 +11,75 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class DiskUsageCollector extends Collector {
 
     private static final Logger logger = LoggerFactory.getLogger(DiskUsageCollector.class);
-    private Jenkins jenkins;
-    private Gauge directoryUsageGauge;
-    private Gauge jobUsageGauge;
-    private boolean collectDiskUsage;
 
-    public DiskUsageCollector() {
-        jenkins = Jenkins.get();
-        this.collectDiskUsage = ConfigurationUtils.getCollectDiskUsage();
+    private static Gauge newDirectoryUsageGauge() {
+        return Gauge.build()
+                .namespace(ConfigurationUtils.getNamespace())
+                .subsystem(ConfigurationUtils.getSubSystem())
+                .name("disk_usage_bytes")
+                .labelNames("directory")
+                .help("Disk usage of first level folder in JENKINS_HOME in bytes")
+                .create();
+    }
 
-        if(collectDiskUsage) {
-            directoryUsageGauge = Gauge.build()
-                    .namespace(ConfigurationUtils.getNamespace())
-                    .subsystem(ConfigurationUtils.getSubSystem())
-                    .name("disk_usage_bytes")
-                    .labelNames("directory")
-                    .help("Disk usage of first level folder in JENKINS_HOME in bytes")
-                    .create();
-            jobUsageGauge = Gauge.build()
-                    .namespace(ConfigurationUtils.getNamespace())
-                    .subsystem(ConfigurationUtils.getSubSystem())
-                    .name("job_usage_bytes")
-                    .labelNames("jobName", "url")
-                    .help("Amount of disk usage (bytes) for each job in Jenkins")
-                    .create();
-        }
+    private static Gauge newJobUsageGauge() {
+        return Gauge.build()
+                .namespace(ConfigurationUtils.getNamespace())
+                .subsystem(ConfigurationUtils.getSubSystem())
+                .name("job_usage_bytes")
+                .labelNames("jobName", "url")
+                .help("Amount of disk usage (bytes) for each job in Jenkins")
+                .create();
     }
 
     @Override
     @Nonnull
     public List<MetricFamilySamples> collect() {
-        List<MetricFamilySamples> samples = new ArrayList<>();
-        if(!this.collectDiskUsage) { return samples; }
-        try {
-        	com.cloudbees.simplediskusage.QuickDiskUsagePlugin diskUsagePlugin = jenkins.getPlugin(com.cloudbees.simplediskusage.QuickDiskUsagePlugin.class);
-            if (diskUsagePlugin == null) {
-                logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not installed.");
-                return samples;
-            }
-            diskUsagePlugin.getDirectoriesUsages().forEach(
-                    i -> directoryUsageGauge.labels(i.getDisplayName())
-                            .set(i.getUsage() * 1024)
-            );
-            samples.addAll(directoryUsageGauge.collect());
-
-            diskUsagePlugin.getJobsUsages().forEach(
-                    i -> jobUsageGauge.labels(i.getFullName(), i.getUrl())
-                            .set(i.getUsage() * 1024)
-            );
-            samples.addAll(jobUsageGauge.collect());
-        } catch (IOException e) {
-            logger.warn("Cannot get disk usage data due to an unexpected error", e);
-        } catch (java.lang.NoClassDefFoundError e) {
-        	logger.warn("Cannot get disk usage data. Install CloudBees Disk Usage Simple plugin to enable");
+        if (!ConfigurationUtils.getCollectDiskUsage()) {
+            return Collections.emptyList();
         }
+
+        try {
+            return collectDiskUsage();
+        } catch (final IOException | RuntimeException e) {
+            logger.warn("Failed to get disk usage data due to an unexpected error.", e);
+            return Collections.emptyList();
+        } catch (final java.lang.NoClassDefFoundError e) {
+            logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not installed: " + e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Nonnull
+    private static List<MetricFamilySamples> collectDiskUsage() throws IOException {
+        final com.cloudbees.simplediskusage.QuickDiskUsagePlugin diskUsagePlugin = Jenkins.get()
+            .getPlugin(com.cloudbees.simplediskusage.QuickDiskUsagePlugin.class);
+        if (diskUsagePlugin == null) {
+            logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not loaded.");
+            return Collections.emptyList();
+        }
+
+        final List<MetricFamilySamples> samples = new ArrayList<>();
+
+        final Gauge directoryUsageGauge = newDirectoryUsageGauge();
+        diskUsagePlugin.getDirectoriesUsages().forEach(
+                i -> directoryUsageGauge.labels(i.getDisplayName())
+                        .set(i.getUsage() * 1024)
+        );
+        samples.addAll(directoryUsageGauge.collect());
+
+        final Gauge jobUsageGauge = newJobUsageGauge();
+        diskUsagePlugin.getJobsUsages().forEach(
+                i -> jobUsageGauge.labels(i.getFullName(), i.getUrl())
+                        .set(i.getUsage() * 1024)
+        );
+        samples.addAll(jobUsageGauge.collect());
         return samples;
     }
 }


### PR DESCRIPTION
The gauges for Jenkins disk usage are currently cached forever. The disk usage plugin prunes old items each time it re-estimates the disk usage, but the metrics previously collected into the gauges are not affected in any way by this. 

### Changes proposed

The easiest way not to export no-longer-existing items is to just recreate the gauges every time for every call to collect().

### Checklist

- [ ] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
