### PR TITLE
Add metrics about file store usage

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -9,33 +9,57 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class DiskUsageCollector extends Collector {
 
     private static final Logger logger = LoggerFactory.getLogger(DiskUsageCollector.class);
 
     private static Gauge newDirectoryUsageGauge() {
-        return Gauge.build()
-                .namespace(ConfigurationUtils.getNamespace())
-                .subsystem(ConfigurationUtils.getSubSystem())
+        return newGaugeBuilder()
                 .name("disk_usage_bytes")
-                .labelNames("directory")
+                .labelNames("file_store", "directory")
                 .help("Disk usage of first level folder in JENKINS_HOME in bytes")
                 .create();
     }
 
     private static Gauge newJobUsageGauge() {
-        return Gauge.build()
-                .namespace(ConfigurationUtils.getNamespace())
-                .subsystem(ConfigurationUtils.getSubSystem())
+        return newGaugeBuilder()
                 .name("job_usage_bytes")
-                .labelNames("jobName", "url")
+                .labelNames("file_store", "jobName", "url")
                 .help("Amount of disk usage (bytes) for each job in Jenkins")
                 .create();
+    }
+
+    private static Gauge newFileStoreCapacityGauge() {
+        return newGaugeBuilder()
+                .name("file_store_capacity_bytes")
+                .labelNames("file_store")
+                .help("Total size in bytes of the file stores used by Jenkins")
+                .create();
+    }
+
+    private static Gauge newFileStoreAvailableGauge() {
+        return newGaugeBuilder()
+                .name("file_store_available_bytes")
+                .labelNames("file_store")
+                .help("Estimated available space on the file stores used by Jenkins")
+                .create();
+    }
+
+    private static Gauge.Builder newGaugeBuilder() {
+        return Gauge.build()
+                .namespace(ConfigurationUtils.getNamespace())
+                .subsystem(ConfigurationUtils.getSubSystem());
     }
 
     @Override
@@ -51,7 +75,7 @@ public class DiskUsageCollector extends Collector {
             logger.warn("Failed to get disk usage data due to an unexpected error.", e);
             return Collections.emptyList();
         } catch (final java.lang.NoClassDefFoundError e) {
-            logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not installed: " + e);
+            logger.warn("Cannot collect disk usage data because plugin CloudBees Disk Usage Simple is not installed: {}", e.toString());
             return Collections.emptyList();
         }
     }
@@ -66,20 +90,62 @@ public class DiskUsageCollector extends Collector {
         }
 
         final List<MetricFamilySamples> samples = new ArrayList<>();
+        final Set<FileStore> usedFileStores = new HashSet<>();
 
         final Gauge directoryUsageGauge = newDirectoryUsageGauge();
-        diskUsagePlugin.getDirectoriesUsages().forEach(
-                i -> directoryUsageGauge.labels(i.getDisplayName())
-                        .set(i.getUsage() * 1024)
-        );
+        diskUsagePlugin.getDirectoriesUsages().forEach(i -> {
+                final Optional<FileStore> fileStore = getFileStore(i.getPath());
+                fileStore.ifPresent(usedFileStores::add);
+                directoryUsageGauge.labels(toLabelValue(fileStore), i.getDisplayName()).set(i.getUsage() * 1024);
+        });
         samples.addAll(directoryUsageGauge.collect());
 
         final Gauge jobUsageGauge = newJobUsageGauge();
-        diskUsagePlugin.getJobsUsages().forEach(
-                i -> jobUsageGauge.labels(i.getFullName(), i.getUrl())
-                        .set(i.getUsage() * 1024)
-        );
+        diskUsagePlugin.getJobsUsages().forEach(i -> {
+                final Optional<FileStore> fileStore = getFileStore(i.getPath());
+                fileStore.ifPresent(usedFileStores::add);
+                jobUsageGauge.labels(toLabelValue(fileStore), i.getFullName(), i.getUrl()).set(i.getUsage() * 1024);
+        });
         samples.addAll(jobUsageGauge.collect());
+
+        final Gauge fileStoreCapacityGauge = newFileStoreCapacityGauge();
+        final Gauge fileStoreAvailableGauge = newFileStoreAvailableGauge();
+        usedFileStores.forEach(store -> {
+                final String labelValue = toLabelValue(Optional.of(store));
+    
+                try {
+                    fileStoreCapacityGauge.labels(labelValue).set(store.getTotalSpace());
+                } catch (final IOException | RuntimeException e) {
+                    logger.debug("Failed to get total space of {}", store, e);
+                    fileStoreCapacityGauge.labels(labelValue).set(Double.NaN);
+                }
+    
+                try {
+                    fileStoreAvailableGauge.labels(labelValue).set(store.getUsableSpace());
+                } catch (final IOException | RuntimeException e) {
+                    logger.debug("Failed to get usable space of {}", store, e);
+                    fileStoreAvailableGauge.labels(labelValue).set(Double.NaN);
+                }
+        });
+        samples.addAll(fileStoreCapacityGauge.collect());
+        samples.addAll(fileStoreAvailableGauge.collect());
+
         return samples;
+    }
+
+    private static String toLabelValue(Optional<FileStore> fileStore) {
+        // At least on Linux, FileStore::name is not unique, whereas FileStore::toString includes the mount point, which
+        // makes it unique. So it's possible to have duplicate metrics with different label values for the same file
+        // store mounted to different paths.
+        return fileStore.map(FileStore::toString).orElse("<unknown>");
+    }
+
+    private static Optional<FileStore> getFileStore(File file) {
+        try {
+            return Optional.of(Files.getFileStore(file.toPath().toRealPath()));
+        } catch (IOException | RuntimeException e) {
+            logger.debug("Failed to get file store for {}", file, e);
+            return Optional.empty();
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/DiskUsageCollectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/DiskUsageCollectorTest.java
@@ -1,0 +1,207 @@
+package org.jenkinsci.plugins.prometheus;
+
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.jenkinsci.plugins.prometheus.util.ConfigurationUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import com.cloudbees.simplediskusage.DiskItem;
+import com.cloudbees.simplediskusage.JobDiskItem;
+import com.cloudbees.simplediskusage.QuickDiskUsagePlugin;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import jenkins.model.Jenkins;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(MockitoJUnitRunner.StrictStubs.class)
+public class DiskUsageCollectorTest {
+
+    @Mock
+    Jenkins jenkins;
+
+    @Mock
+    QuickDiskUsagePlugin quickDiskUsagePlugin;
+
+    final DiskUsageCollector underTest = new DiskUsageCollector();
+
+    @Test
+    @PrepareForTest(ConfigurationUtils.class)
+    public void shouldNotProduceMetricsWhenDisabled() {
+        mockStatic(ConfigurationUtils.class);
+        when(ConfigurationUtils.getCollectDiskUsage()).thenReturn(false);
+
+        final List<MetricFamilySamples> samples = underTest.collect();
+
+        assertThat(samples, is(empty()));
+    }
+
+    @Test
+    @PrepareForTest({ Jenkins.class, ConfigurationUtils.class })
+    public void shouldProdueMetrics() throws IOException {
+        mockStatic(Jenkins.class, ConfigurationUtils.class);
+        when(ConfigurationUtils.getNamespace()).thenReturn("foo");
+        when(ConfigurationUtils.getSubSystem()).thenReturn("bar");
+        when(ConfigurationUtils.getCollectDiskUsage()).thenReturn(true);
+        when(Jenkins.get()).thenReturn(jenkins);
+        when(jenkins.getPlugin(QuickDiskUsagePlugin.class)).thenReturn(quickDiskUsagePlugin);
+
+        final FileStore store = mock(FileStore.class, "the file store");
+        given(store.getTotalSpace()).willReturn(4711L);
+        given(store.getUsableSpace()).willReturn(1337L);
+
+        final DiskItem dir = mock(DiskItem.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
+        given(dir.getDisplayName()).willReturn("dir name");
+        given(dir.getUsage()).willReturn(11L);
+        mockFileStore(dir, store);
+        final CopyOnWriteArrayList<DiskItem> directories = new CopyOnWriteArrayList<>();
+        directories.add(dir);
+        given(quickDiskUsagePlugin.getDirectoriesUsages()).willReturn(directories);
+
+        final JobDiskItem job = mock(JobDiskItem.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
+        given(job.getFullName()).willReturn("job name");
+        given(job.getUrl()).willReturn("/job");
+        given(job.getUsage()).willReturn(7L);
+        mockFileStore(job, store);
+        final CopyOnWriteArrayList<JobDiskItem> jobs = new CopyOnWriteArrayList<>();
+        jobs.add(job);
+        given(quickDiskUsagePlugin.getJobsUsages()).willReturn(jobs);
+
+        final List<MetricFamilySamples> samples = underTest.collect();
+
+        assertThat(samples, containsInAnyOrder(
+            gauges("foo_bar_disk_usage_bytes", containsInAnyOrder(
+                sample(ImmutableMap.of("file_store", "the file store", "directory", "dir"), equalTo(11. * 1024))
+            )),
+            gauges("foo_bar_job_usage_bytes", containsInAnyOrder(
+                sample(ImmutableMap.of("file_store", "the file store", "jobName", "job name", "url", "/job"), equalTo(7. * 1024))
+            )),
+            gauges("foo_bar_file_store_capacity_bytes", containsInAnyOrder(
+                sample(ImmutableMap.of("file_store", "the file store"), equalTo(4711.))
+            )),
+            gauges("foo_bar_file_store_available_bytes", containsInAnyOrder(
+                sample(ImmutableMap.of("file_store", "the file store"), equalTo(1337.))
+            ))
+        ));
+    }
+
+    private static final void mockFileStore(DiskItem item, FileStore store) throws IOException {
+        final Path path = item.getPath().toPath().toRealPath();
+        when(path.getFileSystem().provider().getFileStore(path)).thenReturn(store);
+    }
+
+    private static Matcher<MetricFamilySamples> gauges(String name, Matcher<? super List<MetricFamilySamples.Sample>> samples) {
+        requireNonNull(name);
+        requireNonNull(samples);
+
+        return new TypeSafeDiagnosingMatcher<MetricFamilySamples>(MetricFamilySamples.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("gauges named ")
+                    .appendValue(name)
+                    .appendText(" with samples: ")
+                    .appendDescriptionOf(samples);
+            }
+
+            @Override
+            protected boolean matchesSafely(MetricFamilySamples item, Description mismatchDescription) {
+                if (!Objects.equal(item.name, name)) {
+                    mismatchDescription.appendText("name was ").appendValue(item.name);
+                    return false;
+                }
+
+                if (item.type != Collector.Type.GAUGE) {
+                    mismatchDescription.appendText("type was ").appendValue(item.type);
+                    return false;
+                }
+
+                if (!samples.matches(item.samples)) {
+                    mismatchDescription.appendText("mismatch in samples: ");
+                    samples.describeMismatch(item.samples, mismatchDescription);
+                    return false;
+                }
+
+                return true;
+            }
+        };
+    }
+
+    private static Matcher<MetricFamilySamples.Sample> sample(Map<String, String> labels, Matcher<Double> value) {
+        requireNonNull(labels);
+
+        return new TypeSafeDiagnosingMatcher<MetricFamilySamples.Sample>(MetricFamilySamples.Sample.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("sample labeled ")
+                    .appendValue(labels)
+                    .appendText(" with value ")
+                    .appendDescriptionOf(value);
+            }
+
+            @Override
+            protected boolean matchesSafely(MetricFamilySamples.Sample item, Description mismatchDescription) {
+                if (item.labelNames == null) {
+                    mismatchDescription.appendText("labelNames was ").appendValue(null);
+                    return false;
+                }
+
+                if (item.labelValues == null) {
+                    mismatchDescription.appendText("labelValues was ").appendValue(null);
+                    return false;
+                }
+
+                final Map<String, String> actualLabels = new HashMap<>();
+                final Iterator<String> names = item.labelNames.iterator();
+                final Iterator<String> values = item.labelValues.iterator();
+                while (names.hasNext() && values.hasNext()) {
+                    actualLabels.put(names.next(), values.next());
+                }
+                if (names.hasNext() || values.hasNext()) {
+                    mismatchDescription.appendText("number of label names doesn't match number of label values");
+                }
+
+                if (!actualLabels.equals(labels)) {
+                    mismatchDescription.appendText("labels were ").appendValue(actualLabels);
+                }
+
+                if (!value.matches(item.value)) {
+                    value.describeMismatch(item.value, mismatchDescription);
+                    return false;
+                }
+
+                return true;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Changes proposed

In addition to the storage statistics for folders and jobs, also add metrics about file stores (a.k.a. disks / partitions) on which those folders and jobs are stored.

This adds the two new metrics `file_store_capacity_bytes` and `file_store_available_bytes`, along with the new label `file_store`, that's attached to each folder and job and identifies on which file store they live.

### Checklist

- [x] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
