### PR TITLE
Disable DiskUsageCollector when its option is unchecked (JENKINS-66790)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -132,7 +132,9 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     public void setCollectDiskUsage(Boolean collectDiskUsage) {
         if (collectDiskUsage == null) {
             Map<String, String> env = System.getenv();
-            this.collectDiskUsage = Boolean.parseBoolean(env.getOrDefault(COLLECT_DISK_USAGE, "true"));
+            this.collectDiskUsage = Boolean.parseBoolean(
+                env.getOrDefault(COLLECT_DISK_USAGE, String.valueOf(DEFAULT_COLLECT_DISK_USAGE))
+            );
         }
         else {
             this.collectDiskUsage = collectDiskUsage;
@@ -145,7 +147,14 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         return collectDiskUsage;
     }
 
-    public boolean getDefaultCollectDiskUsage() {return DEFAULT_COLLECT_DISK_USAGE; }
+    /**
+     * Do not use it.
+     * @deprecated the method is not used in the plugin and will be removed in the future.
+     */
+    @Deprecated
+    public boolean getDefaultCollectDiskUsage() {
+        return DEFAULT_COLLECT_DISK_USAGE;
+    }
 
     public long getCollectingMetricsPeriodInSeconds() {
         return collectingMetricsPeriodInSeconds;

--- a/src/main/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtils.java
@@ -19,10 +19,6 @@ public class ConfigurationUtils {
     }
 
     public static boolean getCollectDiskUsage() {
-        String envCollectDiskUsage = System.getenv("COLLECT_DISK_USAGE");
-        if(StringUtils.isEmpty(envCollectDiskUsage)) {
-            return PrometheusConfiguration.get().getDefaultCollectDiskUsage();
-        }
-        return Boolean.parseBoolean(envCollectDiskUsage);
+        return PrometheusConfiguration.get().getCollectDiskUsage();
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtilsTest.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.prometheus.util;
+
+import hudson.ExtensionList;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.jenkinsci.plugins.prometheus.config.PrometheusConfiguration;
+import org.junit.runner.RunWith;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class ConfigurationUtilsTest {
+
+    @Rule
+    public final JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    @Parameters({"true", "false"})
+    public void verifyGetCollectDiskUsage(boolean value) {
+        // given
+        List<PrometheusConfiguration> extensions = ExtensionList.lookup(PrometheusConfiguration.class);
+        PrometheusConfiguration configuration = extensions.get(0);
+        configuration.setCollectDiskUsage(value);
+
+        // when
+        boolean result = ConfigurationUtils.getCollectDiskUsage();
+
+        // then
+        assertThat(result).isEqualTo(value);
+    }
+}


### PR DESCRIPTION
Fixes [JENKINS-66790](https://issues.jenkins.io/browse/JENKINS-66790)

### Changes proposed

The `DiskUsageCollector` class uses the `ConfigurationUtils#getCollectDiskUsage` method to determine whether the it should be enabled or not. Unfortunately, the mentioned method ignores the checkbox configuration option available on the `Configure System` page. The `PrometheusConfiguration` class keeps the requested value in the `collectDiskUsage` field. It is calculated based on the saved configuration which fallback to the `COLLECT_DISK_USAGE` environment variable or `true` (if the environment variable is not set). The `ConfigurationUtils#getCollectDiskUsage` method is updated to execute the `PrometheusConfiguration#getCollectDiskUsage()` method, so the user configuration is taken into account.

### Checklist

- [x] Includes tests covering the new functionality?
- [ ] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
