### PR TITLE
Per job metrics

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -19,7 +19,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.jenkinsci.plugins.prometheus.util.FlowNodes.getSortedStageNodes;
@@ -54,35 +56,35 @@ public class JobCollector extends Collector {
 
         public void initCollectors(String fullname, String subsystem, String namespace, String[] labelNameArray, String[] labelStageNameArray) {
             this.jobBuildResultOrdinal = Gauge.build()
-                    .name(fullname + this.buildPrefix +"_build_result_ordinal")
+                    .name(fullname + this.buildPrefix + "_build_result_ordinal")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelNameArray)
                     .help("Build status of a job.")
                     .create();
 
             this.jobBuildResult = Gauge.build()
-                    .name(fullname + this.buildPrefix +"_build_result")
+                    .name(fullname + this.buildPrefix + "_build_result")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelNameArray)
                     .help("Build status of a job as a boolean (0 or 1)")
                     .create();
 
             this.jobBuildDuration = Gauge.build()
-                    .name(fullname + this.buildPrefix +"_build_duration_milliseconds")
+                    .name(fullname + this.buildPrefix + "_build_duration_milliseconds")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelNameArray)
                     .help("Build times in milliseconds of last build")
                     .create();
 
             this.jobBuildStartMillis = Gauge.build()
-                    .name(fullname + this.buildPrefix +"_build_start_time_milliseconds")
+                    .name(fullname + this.buildPrefix + "_build_start_time_milliseconds")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelNameArray)
                     .help("Last build start timestamp in milliseconds")
                     .create();
 
             this.jobBuildTestsTotal = Gauge.build()
-                    .name(fullname + this.buildPrefix +"_build_tests_total")
+                    .name(fullname + this.buildPrefix + "_build_tests_total")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelNameArray)
                     .help("Number of total tests during the last build")
@@ -96,13 +98,13 @@ public class JobCollector extends Collector {
                     .create();
 
             this.jobBuildTestsFailing = Gauge.build()
-                    .name(fullname + this.buildPrefix +"_build_tests_failing")
+                    .name(fullname + this.buildPrefix + "_build_tests_failing")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelNameArray)
                     .help("Number of failing tests during the last build")
                     .create();
 
-            this.stageSummary = Summary.build().name(fullname + this.buildPrefix +"_stage_duration_milliseconds_summary")
+            this.stageSummary = Summary.build().name(fullname + this.buildPrefix + "_stage_duration_milliseconds_summary")
                     .subsystem(subsystem).namespace(namespace)
                     .labelNames(labelStageNameArray)
                     .help("Summary of Jenkins build times by Job and Stage in the last build")
@@ -128,15 +130,15 @@ public class JobCollector extends Collector {
         String[] labelBaseNameArray = {jobAttribute, "repo", "buildable"};
 
         String[] labelNameArray = labelBaseNameArray;
-        if( PrometheusConfiguration.get().isAppendParamLabel() ){
+        if (PrometheusConfiguration.get().isAppendParamLabel()) {
             labelNameArray = Arrays.copyOf(labelNameArray, labelNameArray.length + 1);
             labelNameArray[labelNameArray.length - 1] = "parameters";
         }
-        if( PrometheusConfiguration.get().isAppendStatusLabel() ){
+        if (PrometheusConfiguration.get().isAppendStatusLabel()) {
             labelNameArray = Arrays.copyOf(labelNameArray, labelNameArray.length + 1);
             labelNameArray[labelNameArray.length - 1] = "status";
         }
-        
+
         String[] buildParameterNamesAsArray = PrometheusConfiguration.get().getLabeledBuildParameterNamesAsArray();
         for (String buildParam : buildParameterNamesAsArray) {
             labelNameArray = Arrays.copyOf(labelNameArray, labelNameArray.length + 1);
@@ -195,23 +197,21 @@ public class JobCollector extends Collector {
         lastBuildMetrics.initCollectors(fullname, subsystem, namespace, labelBaseNameArray, labelStageNameArray);
 
         Jobs.forEachJob(job -> {
-            try{
+            try {
                 if (!job.isBuildable() && processDisabledJobs) {
                     logger.debug("job [{}] is disabled", job.getFullName());
                     return;
                 }
                 logger.debug("Collecting metrics for job [{}]", job.getFullName());
                 appendJobMetrics(job);
-            }
-            catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException e) {
                 if (!e.getMessage().contains("Incorrect number of labels")) {
                     logger.warn("Caught error when processing job [{}] error: ", job.getFullName(), e);
                 } // else - ignore exception
-            }
-            catch( Exception e ){
+            } catch (Exception e) {
                 logger.warn("Caught error when processing job [{}] error: ", job.getFullName(), e);
             }
-            
+
         });
 
         addSamples(samples, summary.collect(), "Adding [{}] samples from summary");
@@ -249,7 +249,7 @@ public class JobCollector extends Collector {
         if (repoName == null) {
             repoName = NOT_AVAILABLE;
         }
-        String[] baseLabelValueArray = {job.getFullName(), repoName, String.valueOf( job.isBuildable() ) };
+        String[] baseLabelValueArray = {job.getFullName(), repoName, String.valueOf(job.isBuildable())};
 
         Run lastBuild = job.getLastBuild();
         // Never built
@@ -272,24 +272,24 @@ public class JobCollector extends Collector {
             logger.debug("getting metrics for run [{}] from job [{}]", run.getNumber(), job.getName());
             if (Runs.includeBuildInMetrics(run)) {
                 logger.debug("getting build info for run [{}] from job [{}]", run.getNumber(), job.getName());
-                
+
                 Result runResult = run.getResult();
                 String[] labelValueArray = baseLabelValueArray;
 
-                if( isAppendParamLabel ){
+                if (isAppendParamLabel) {
                     String params = Runs.getBuildParameters(run).entrySet().stream().map(e -> "" + e.getKey() + "=" + String.valueOf(e.getValue())).collect(Collectors.joining(";"));
                     labelValueArray = Arrays.copyOf(labelValueArray, labelValueArray.length + 1);
                     labelValueArray[labelValueArray.length - 1] = params;
                 }
-                if( isAppendStatusLabel ){
+                if (isAppendStatusLabel) {
                     String resultString = UNDEFINED;
                     if (runResult != null) {
                         resultString = runResult.toString();
                     }
                     labelValueArray = Arrays.copyOf(labelValueArray, labelValueArray.length + 1);
-                    labelValueArray[labelValueArray.length - 1] =  run.isBuilding() ? "RUNNING" : resultString;
+                    labelValueArray[labelValueArray.length - 1] = run.isBuilding() ? "RUNNING" : resultString;
                 }
-                
+
                 for (String configBuildParam : buildParameterNamesAsArray) {
                     labelValueArray = Arrays.copyOf(labelValueArray, labelValueArray.length + 1);
                     String paramValue = UNDEFINED;
@@ -329,7 +329,7 @@ public class JobCollector extends Collector {
             ordinal = runResult.ordinal;
         }
 
-         /*
+        /*
          * _last_build_result _last_build_result_ordinal
          *
          * SUCCESS   0 true  - The build had no errors.

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -53,6 +53,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     private boolean appendParamLabel = false;
     private boolean appendStatusLabel = false;
+    private boolean perBuildMetrics = false;
 
 
     private String labeledBuildParameterNames = "";
@@ -89,6 +90,7 @@ public class PrometheusConfiguration extends GlobalConfiguration {
         processingDisabledBuilds = json.getBoolean("processingDisabledBuilds");
         appendParamLabel = json.getBoolean("appendParamLabel");
         appendStatusLabel = json.getBoolean("appendStatusLabel");
+        perBuildMetrics = json.getBoolean("perBuildMetrics");
 
       labeledBuildParameterNames = json.getString("labeledBuildParameterNames");
 
@@ -244,6 +246,15 @@ public class PrometheusConfiguration extends GlobalConfiguration {
 
     public void setAppendStatusLabel(boolean appendStatusLabel) {
         this.appendStatusLabel = appendStatusLabel;
+        save();
+    }
+
+    public boolean isPerBuildMetrics() {
+        return perBuildMetrics;
+    }
+
+    public void setPerBuildMetrics(boolean perBuildMetrics) {
+        this.perBuildMetrics = perBuildMetrics;
         save();
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -49,5 +49,8 @@
     <f:entry title="${%Collect disk usage}" field="collectDiskUsage">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Collect metrics for each run per build [Important: read help before enabling this option]}" field="perBuildMetrics">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-perBuildMetrics.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-perBuildMetrics.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p class="warning">
+      Use with caution! This option generates lots of metrics which can lead to a multitude of errors and/or high resource consumption.
+      Be sure you know about the consequences and implications before using this option (e.g. Prometheus disk usage)!
+    </p>
+    <p>
+    Enable per run metrics. This will create metrics for each run of each build including status, startTime, duration, etc.
+    Make sure your total number of runs in Jenkins is limited by using the "discard old builds" feature.
+    </p>
+  </div>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfigurationTest.java
@@ -149,6 +149,7 @@ public class PrometheusConfigurationTest {
         config.accumulate("appendStatusLabel", "false");
         config.accumulate("labeledBuildParameterNames", "");
         config.accumulate("collectDiskUsage", "true");
+        config.accumulate("perBuildMetrics", "false");
         return config;
     }
 


### PR DESCRIPTION
This basically re-adds the per run metrics initially added with #177 and were removed in #230 
Unfortunately those metrics can easily blow up a Jenkins instance by their sheer number, so this time those metrics are disabled by default and can be enabled (there is a warning in the UI).

The use case for those metrics are short histories of jobs (e.g. having only 10 runs in Jenkins) with their characteristics heavily dependent on parameters and a need to have metrics for a much longer time.

### Changes proposed

- make it possible to enable per build metrics if desired

### Checklist

- [ ] Includes tests covering the new functionality?
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
