### PR TITLE
Fixing hpi build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(jdkVersions: [11])

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
   <properties>
     <!-- when updated the io.jenkins.tools.bom:bom-X.Y.Z must be updated too -->
-    <jenkins.version>2.319.3</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.361</jenkins.version>
+    <java.level>11</java.level>
 
     <prometheus.simpleclient.version>0.16.0</prometheus.simpleclient.version>
     <slf4j.version>2.0.5</slf4j.version>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JobCollector.java
@@ -391,14 +391,12 @@ public class JobCollector extends Collector {
     }
 
     private void processPipelineRunStages(Job job, Run latestfinishedRun, WorkflowRun workflowRun, Summary stageSummary) {
-        try {
-            logger.debug("getting the sorted stage nodes for run[{}] from job [{}]", latestfinishedRun.getNumber(), job.getName());
-            List<StageNodeExt> stages = getSortedStageNodes(workflowRun);
-            for (StageNodeExt stage : stages) {
+        logger.debug("Getting the sorted stage nodes for run[{}] from job [{}]", latestfinishedRun.getNumber(), job.getName());
+        List<StageNodeExt> stages = getSortedStageNodes(workflowRun);
+        for (StageNodeExt stage : stages) {
+            if (stage != null && stageSummary != null) {
                 observeStage(job, latestfinishedRun, stage, stageSummary);
             }
-        } catch (NullPointerException e) {
-            // ignored
         }
     }
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<div>
+Jenkins Prometheus Plugin expose an endpoint (default /prometheus) with metrics where a Prometheus Server can scrape.
+</div>
+


### PR DESCRIPTION
Fixes the hpi build

### Changes proposed

- Dependabot updated the parent to 4.52 so we need to update to jenkins > 2.361 + java 11 in order to build the hpi file

### Checklist

- [-] Includes tests covering the new functionality?
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules

### Notify
