### PR TITLE
Bugfix - Collect Disk Usage is stored correctly

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/config.jelly
@@ -47,7 +47,8 @@
       <f:textbox />
     </f:entry>
     <f:entry title="${%Collect disk usage}" field="collectDiskUsage">
-      <f:checkbox/>
+      <j:set var="readOnlyMode" value="${instance.isEnvironmentVariableSet()}"/>
+      <f:checkbox />
     </f:entry>
     <f:entry title="${%Collect node status}" field="collectNodeStatus">
       <f:checkbox/>

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-collectDiskUsage.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-collectDiskUsage.jelly
@@ -3,6 +3,8 @@
   <div>
     <p>
       If prometheus should collect disk usage or not. Disable this if you are using a cloud storage provider.
+      You can overwrite the default behavior with the environment variable COLLECT_DISK_USAGE.
+      This field is disabled if the variable is set.
     </p>
   </div>
 </j:jelly>


### PR DESCRIPTION
Fixes #482

### Changes proposed

- The Environment variable COLLECT_DISK_USAGE takes the lead. If it's set to a valid boolean parameter this configuration wins. Otherwise the configured value over the Jenkins configuration page is taken. If the Environment variable is set, then the configuration item in the Jenkins page is disabled. 

### Checklist

- [x] Ready for review

### Notify

@markyjackson-taulia. Do you think that is a valid fix?
