### PR TITLE
Prepare to test Java 21

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2446.v2e9fd3b_d8c81</version>
+        <version>2496.vddfca_753db_80</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.73</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
 
@@ -25,7 +25,7 @@
     <slf4j.version>2.0.9</slf4j.version>
 
     <cloudbees-disk-usage-simple.version>0.10</cloudbees-disk-usage-simple.version>
-    <code-coverage-api.version>4.7.0</code-coverage-api.version>
+    <code-coverage-api.version>4.8.0</code-coverage-api.version>
     <metrics.version>4.2.18-442.v02e107157925</metrics.version>
     <pipeline-rest-api.version>2.21</pipeline-rest-api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,16 @@
       <artifactId>pipeline-rest-api</artifactId>
     </dependency>
 
+    <!-- mockito must precede assertj until assertj supports Java 21 -->
+    <!-- mockito provides a Java 21 capable version of bytebuddy -->
+    <!-- TODO: restore ordering once assertj supports Java 21 -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- assertj must follow mockito until assertj supports Java 21 -->
+    <!-- assertj does not provide a Java 21 capable version of bytebuddy -->
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -152,18 +162,6 @@
       <version>${JUnitParams.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-<!--    <dependency>-->
-<!--      <groupId>org.mockito</groupId>-->
-<!--      <artifactId>mockito-inline</artifactId>-->
-<!--      <version>${mockito.version}</version>-->
-<!--      <scope>test</scope>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-lambda</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,6 @@
 
     <cloudbees-disk-usage-simple.version>0.10</cloudbees-disk-usage-simple.version>
     <code-coverage-api.version>4.8.0</code-coverage-api.version>
-    <metrics.version>4.2.18-442.v02e107157925</metrics.version>
-    <pipeline-rest-api.version>2.21</pipeline-rest-api.version>
 
     <assertj-core.version>3.24.2</assertj-core.version>
     <JUnitParams.version>1.1.1</JUnitParams.version>
@@ -136,12 +134,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>${metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
       <artifactId>pipeline-rest-api</artifactId>
-      <version>${pipeline-rest-api.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
   <properties>
     <!-- when updated the io.jenkins.tools.bom:bom-X.Y.Z must be updated too -->
     <jenkins.version>2.387.3</jenkins.version>
-    <java.level>11</java.level>
 
     <prometheus.simpleclient.version>0.16.0</prometheus.simpleclient.version>
     <slf4j.version>2.0.9</slf4j.version>


### PR DESCRIPTION
## Prepare to test Java 21

Preparing to test with Java 21 as part of [JENKINS-71800](https://issues.jenkins.io/browse/JENKINS-71800).

### Changes proposed

Fix Java 21 tests by placing mockito before assertj

[The bytebuddy mailing list](https://groups.google.com/g/byte-buddy/c/H3auRC-SRts/m/7NCRN2wAAwAJ) notes that the version of bytebuddy in assertj does not support Java 21 while the version of bytebuddy in mockito supports Java 21.  Load mockito first so that the newer version of bytebuddy is used for the tests.

This change is **necessary but not sufficient** to pass the tests on Java 21.  The tests run much better on Java 21 with this change, but there are still two tests that fail on both Java 17 and Java 21.  They will need to be investigated and resolved in a separate pull request.

Use plugin BOM to provide metrics and rest API versions

Remove unnecessary java.level property

Supersedes or includes the following pull requests:

* #570
* #569
* #568
* #561

### Checklist

- [x] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@Waschndolos
