### PR TITLE
chore: bump simple disk usage to include new metric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <prometheus.simpleclient.version>0.16.0</prometheus.simpleclient.version>
     <slf4j.version>2.0.9</slf4j.version>
 
-    <cloudbees-disk-usage-simple.version>0.10</cloudbees-disk-usage-simple.version>
+    <cloudbees-disk-usage-simple.version>187.v6378d330d1d4</cloudbees-disk-usage-simple.version>
     <code-coverage-api.version>4.8.0</code-coverage-api.version>
 
     <assertj-core.version>3.24.2</assertj-core.version>


### PR DESCRIPTION
Add new disk metric for file count to prometheus metrics plugin (introduced in #https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/92)


### Changes proposed

- Bump cloudbees-disk-usage-simple-plugin to 187.v6378d330d1d4 (adds new file count metric)
 
### Checklist

- [ ] Includes tests covering the new functionality?
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules

### Notify

@Waschndolos
