### PR TITLE
Removing deprecated code-coverage-api plugin dependency and fixing job_name attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,17 +24,12 @@
     <slf4j.version>2.0.9</slf4j.version>
 
     <cloudbees-disk-usage-simple.version>187.v6378d330d1d4</cloudbees-disk-usage-simple.version>
-    <code-coverage-api.version>4.99.0</code-coverage-api.version>
+    <coverage.version>1.7.0</coverage.version>
 
     <assertj-core.version>3.24.2</assertj-core.version>
     <JUnitParams.version>1.1.1</JUnitParams.version>
     <system-lambda.version>1.2.1</system-lambda.version>
   </properties>
-
-  <organization>
-    <name>Methodair</name>
-    <url>http://www.methodair.io</url>
-  </organization>
 
   <licenses>
     <license>
@@ -47,12 +42,6 @@
   <developers>
     <developer>
       <id>Waschndolos</id>
-    </developer>
-    <developer>
-      <id>devguy</id>
-      <name>Marky Jackson</name>
-      <organization>Methodair</organization>
-      <organizationUrl>http://www.methodair.io/</organizationUrl>
     </developer>
   </developers>
 
@@ -123,8 +112,8 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>code-coverage-api</artifactId>
-      <version>${code-coverage-api.version}</version>
+      <artifactId>coverage</artifactId>
+      <version>${coverage.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/CodeCoverageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/CodeCoverageCollector.java
@@ -27,12 +27,12 @@ public class CodeCoverageCollector extends BaseCollector {
     @Override
     public List<MetricFamilySamples> collect() {
 
-        if (!isCodeCoverageAPIPluginLoaded()) {
+        if (!isCoveragePluginLoaded()) {
             LOGGER.debug("Cannot collect code coverage data because plugin Code Coverage API (shortname: 'code-coverage-api') is not loaded.");
             return Collections.emptyList();
         }
 
-        if (!isCodeCoverageCollectionConfigured()) {
+        if (!isCoverageCollectionConfigured()) {
             return Collections.emptyList();
         }
 
@@ -61,21 +61,23 @@ public class CodeCoverageCollector extends BaseCollector {
         CollectorFactory factory = new CollectorFactory();
         List<MetricCollector<Run<?,?>, ? extends Collector>> collectors = new ArrayList<>();
 
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_COVERED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_MISSED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_TOTAL, new String[]{"job_name"}));
+        String jobAttributeName = PrometheusConfiguration.get().getJobAttributeName();
 
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_COVERED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_MISSED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_TOTAL, new String[]{"job_name"}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_COVERED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_MISSED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_TOTAL, new String[]{jobAttributeName}));
 
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_COVERED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_MISSED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_TOTAL, new String[]{"job_name"}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_COVERED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_MISSED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_TOTAL, new String[]{jobAttributeName}));
 
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_COVERED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_MISSED, new String[]{"job_name"}));
-        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_TOTAL, new String[]{"job_name"}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_COVERED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_MISSED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_TOTAL, new String[]{jobAttributeName}));
+
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_COVERED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_MISSED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_TOTAL, new String[]{jobAttributeName}));
 
         collectors.forEach(c -> c.calculateMetric(lastBuild, new String[]{job.getName()}));
 
@@ -84,11 +86,11 @@ public class CodeCoverageCollector extends BaseCollector {
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
     }
-    private boolean isCodeCoverageAPIPluginLoaded() {
-        return Jenkins.get().getPlugin("code-coverage-api") != null;
+    private boolean isCoveragePluginLoaded() {
+        return Jenkins.get().getPlugin("coverage") != null;
     }
 
-    private boolean isCodeCoverageCollectionConfigured() {
+    private boolean isCoverageCollectionConfigured() {
         return PrometheusConfiguration.get().isCollectCodeCoverage();
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-collectCodeCoverage.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration/help-collectCodeCoverage.jelly
@@ -2,8 +2,8 @@
 <j:jelly xmlns:j="jelly:core">
     <div>
         <p>
-            If prometheus should collect code coverage metrics from code-coverage-api plugin.
-            This option is disabled when code-coverage-api plugin is not installed.
+            If prometheus should collect code coverage metrics from https://plugins.jenkins.io/coverage plugin.
+            This option is disabled when coverage plugin is not installed.
         </p>
     </div>
 </j:jelly>


### PR DESCRIPTION
* Removing deprecated coverage-api plugin and using successor plugin
* Using jobAttributeName from configuration instead of "job_name"

Fixes #607 

### Checklist

- [x] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

