### PR TITLE
Code coverage will not show job full name. Provide a default value of -1 if a specific coverage is not available in the coverage report

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/CodeCoverageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/CodeCoverageCollector.java
@@ -66,18 +66,27 @@ public class CodeCoverageCollector extends BaseCollector {
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_COVERED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_MISSED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_TOTAL, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_CLASS_PERCENT, new String[]{jobAttributeName}));
 
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_COVERED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_MISSED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_TOTAL, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_BRANCH_PERCENT, new String[]{jobAttributeName}));
 
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_COVERED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_MISSED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_TOTAL, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_INSTRUCTION_PERCENT, new String[]{jobAttributeName}));
 
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_COVERED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_MISSED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_TOTAL, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_PERCENT, new String[]{jobAttributeName}));
+
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_LINE_COVERED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_LINE_MISSED, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_LINE_TOTAL, new String[]{jobAttributeName}));
+        collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_LINE_PERCENT, new String[]{jobAttributeName}));
 
         collectors.forEach(c -> c.calculateMetric(lastBuild, new String[]{job.getFullName()}));
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/CodeCoverageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/CodeCoverageCollector.java
@@ -79,7 +79,7 @@ public class CodeCoverageCollector extends BaseCollector {
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_MISSED, new String[]{jobAttributeName}));
         collectors.add(factory.createCoverageRunCollector(CollectorType.COVERAGE_FILE_TOTAL, new String[]{jobAttributeName}));
 
-        collectors.forEach(c -> c.calculateMetric(lastBuild, new String[]{job.getName()}));
+        collectors.forEach(c -> c.calculateMetric(lastBuild, new String[]{job.getFullName()}));
 
         return collectors.stream()
                 .map(MetricCollector::collect)

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/CollectorType.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/CollectorType.java
@@ -45,18 +45,27 @@ public enum CollectorType {
     COVERAGE_CLASS_COVERED("coverage_class_covered"),
     COVERAGE_CLASS_MISSED("coverage_class_missed"),
     COVERAGE_CLASS_TOTAL("coverage_class_total"),
+    COVERAGE_CLASS_PERCENT("coverage_class_percent"),
 
     COVERAGE_BRANCH_COVERED("coverage_branch_covered"),
     COVERAGE_BRANCH_MISSED("coverage_branch_missed"),
     COVERAGE_BRANCH_TOTAL("coverage_branch_total"),
+    COVERAGE_BRANCH_PERCENT("coverage_branch_percent"),
 
     COVERAGE_INSTRUCTION_COVERED("coverage_instruction_covered"),
     COVERAGE_INSTRUCTION_MISSED("coverage_instruction_missed"),
     COVERAGE_INSTRUCTION_TOTAL("coverage_instruction_total"),
+    COVERAGE_INSTRUCTION_PERCENT("coverage_instruction_percent"),
 
     COVERAGE_FILE_COVERED("coverage_file_covered"),
     COVERAGE_FILE_MISSED("coverage_file_missed"),
     COVERAGE_FILE_TOTAL("coverage_file_total"),
+    COVERAGE_FILE_PERCENT("coverage_file_percent"),
+
+    COVERAGE_LINE_COVERED("coverage_line_covered"),
+    COVERAGE_LINE_MISSED("coverage_line_missed"),
+    COVERAGE_LINE_TOTAL("coverage_line_total"),
+    COVERAGE_LINE_PERCENT("coverage_line_percent"),
 
     JOB_LOG_UPDATED_GAUGE("job_log_updated");
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchCoveredGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchCoveredGauge.java
@@ -36,6 +36,7 @@ public class CoverageBranchCoveredGauge extends CoverageMetricsCollector<Run<?, 
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.BRANCH, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchMissedGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchMissedGauge.java
@@ -36,6 +36,7 @@ public class CoverageBranchMissedGauge extends CoverageMetricsCollector<Run<?, ?
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.BRANCH, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchPercentGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchPercentGauge.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageBranchPercentGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageBranchPercentGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_BRANCH_PERCENT;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the coverage of branches in percent";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.BRANCH, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(calculatePercentage(coverage));
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchTotalGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchTotalGauge.java
@@ -36,6 +36,7 @@ public class CoverageBranchTotalGauge extends CoverageMetricsCollector<Run<?, ?>
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.BRANCH, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassCoveredGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassCoveredGauge.java
@@ -36,6 +36,7 @@ public class CoverageClassCoveredGauge extends CoverageMetricsCollector<Run<?, ?
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.CLASS, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassMissedGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassMissedGauge.java
@@ -36,6 +36,7 @@ public class CoverageClassMissedGauge extends CoverageMetricsCollector<Run<?, ?>
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.CLASS, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassPercentGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassPercentGauge.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageClassPercentGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageClassPercentGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_CLASS_PERCENT;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the coverage of classes in percent";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.CLASS, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(calculatePercentage(coverage));
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassTotalGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassTotalGauge.java
@@ -36,6 +36,7 @@ public class CoverageClassTotalGauge extends CoverageMetricsCollector<Run<?, ?>,
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.CLASS, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageCollectorFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageCollectorFactory.java
@@ -17,24 +17,45 @@ public class CoverageCollectorFactory extends BaseCollectorFactory {
                 return saveBuildCollector(new CoverageClassMissedGauge(labelNames, namespace, subsystem));
             case COVERAGE_CLASS_TOTAL:
                 return saveBuildCollector(new CoverageClassTotalGauge(labelNames, namespace, subsystem));
+            case COVERAGE_CLASS_PERCENT:
+                return saveBuildCollector(new CoverageClassPercentGauge(labelNames, namespace, subsystem));
+
             case COVERAGE_BRANCH_COVERED:
                 return saveBuildCollector(new CoverageBranchCoveredGauge(labelNames, namespace, subsystem));
             case COVERAGE_BRANCH_MISSED:
                 return saveBuildCollector(new CoverageBranchMissedGauge(labelNames, namespace, subsystem));
             case COVERAGE_BRANCH_TOTAL:
                 return saveBuildCollector(new CoverageBranchTotalGauge(labelNames, namespace, subsystem));
+            case COVERAGE_BRANCH_PERCENT:
+                return saveBuildCollector(new CoverageBranchPercentGauge(labelNames, namespace, subsystem));
+
             case COVERAGE_INSTRUCTION_COVERED:
                 return saveBuildCollector(new CoverageInstructionCoveredGauge(labelNames, namespace, subsystem));
             case COVERAGE_INSTRUCTION_MISSED:
                 return saveBuildCollector(new CoverageInstructionMissedGauge(labelNames, namespace, subsystem));
             case COVERAGE_INSTRUCTION_TOTAL:
                 return saveBuildCollector(new CoverageInstructionTotalGauge(labelNames, namespace, subsystem));
+            case COVERAGE_INSTRUCTION_PERCENT:
+                return saveBuildCollector(new CoverageInstructionPercentGauge(labelNames, namespace, subsystem));
+
             case COVERAGE_FILE_COVERED:
                 return saveBuildCollector(new CoverageFileCoveredGauge(labelNames, namespace, subsystem));
             case COVERAGE_FILE_MISSED:
                 return saveBuildCollector(new CoverageFileMissedGauge(labelNames, namespace, subsystem));
             case COVERAGE_FILE_TOTAL:
                 return saveBuildCollector(new CoverageFileTotalGauge(labelNames, namespace, subsystem));
+            case COVERAGE_FILE_PERCENT:
+                return saveBuildCollector(new CoverageFilePercentGauge(labelNames, namespace, subsystem));
+
+            case COVERAGE_LINE_COVERED:
+                return saveBuildCollector(new CoverageLineCoveredGauge(labelNames, namespace, subsystem));
+            case COVERAGE_LINE_MISSED:
+                return saveBuildCollector(new CoverageLineMissedGauge(labelNames, namespace, subsystem));
+            case COVERAGE_LINE_TOTAL:
+                return saveBuildCollector(new CoverageLineTotalGauge(labelNames, namespace, subsystem));
+            case COVERAGE_LINE_PERCENT:
+                return saveBuildCollector(new CoverageLinePercentGauge(labelNames, namespace, subsystem));
+
             default:
                 return new NoOpMetricCollector<>();
         }

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileCoveredGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileCoveredGauge.java
@@ -36,6 +36,7 @@ public class CoverageFileCoveredGauge extends CoverageMetricsCollector<Run<?, ?>
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.FILE, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileMissedGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileMissedGauge.java
@@ -36,6 +36,7 @@ public class CoverageFileMissedGauge extends CoverageMetricsCollector<Run<?, ?>,
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.FILE, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFilePercentGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFilePercentGauge.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageFilePercentGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageFilePercentGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_FILE_PERCENT;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the coverage of files in percent";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.FILE, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(calculatePercentage(coverage));
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileTotalGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileTotalGauge.java
@@ -36,6 +36,7 @@ public class CoverageFileTotalGauge extends CoverageMetricsCollector<Run<?, ?>, 
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.FILE, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionCoveredGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionCoveredGauge.java
@@ -36,6 +36,7 @@ public class CoverageInstructionCoveredGauge extends CoverageMetricsCollector<Ru
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.INSTRUCTION, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionMissedGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionMissedGauge.java
@@ -36,6 +36,7 @@ public class CoverageInstructionMissedGauge extends CoverageMetricsCollector<Run
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.INSTRUCTION, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionPercentGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionPercentGauge.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageInstructionPercentGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageInstructionPercentGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_INSTRUCTION_PERCENT;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the coverage of instructions in percent";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.INSTRUCTION, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(calculatePercentage(coverage));
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionTotalGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionTotalGauge.java
@@ -36,6 +36,7 @@ public class CoverageInstructionTotalGauge extends CoverageMetricsCollector<Run<
 
         Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.INSTRUCTION, Baseline.PROJECT);
         if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineCoveredGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineCoveredGauge.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageLineCoveredGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageLineCoveredGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_LINE_COVERED;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the number of lines covered";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.LINE, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(coverage.getCovered());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineMissedGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineMissedGauge.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageLineMissedGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageLineMissedGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_LINE_MISSED;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the number of lines missed";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.LINE, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(coverage.getMissed());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLinePercentGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLinePercentGauge.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageLinePercentGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageLinePercentGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_LINE_PERCENT;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the coverage of lines in percent";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.LINE, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(calculatePercentage(coverage));
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineTotalGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineTotalGauge.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Coverage;
+import edu.hm.hafner.coverage.Metric;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+import java.util.Optional;
+
+public class CoverageLineTotalGauge extends CoverageMetricsCollector<Run<?, ?>, Gauge> {
+
+    protected CoverageLineTotalGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.COVERAGE_LINE_TOTAL;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Returns the number of lines total";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Run<?, ?> jenkinsObject, String[] labelValues) {
+
+        Optional<Coverage> optional = getCoverage(jenkinsObject, Metric.LINE, Baseline.PROJECT);
+        if (optional.isEmpty()) {
+            collector.labels(labelValues).set(-1);
+            return;
+        }
+
+        Coverage coverage = optional.get();
+        collector.labels(labelValues).set(coverage.getTotal());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageMetricsCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageMetricsCollector.java
@@ -27,4 +27,23 @@ public abstract class CoverageMetricsCollector<T, I extends SimpleCollector<?>> 
                 .map(x -> (Coverage)x)
                 .findFirst();
     }
+
+    protected double calculatePercentage(Coverage coverage) {
+        if (coverage == null) {
+            return -1.0;
+        }
+
+        long covered = coverage.getCovered();
+        long total = coverage.getTotal();
+
+        if (covered >= 0 && total >= 0) {
+            if (total != 0) {
+                return (double) (covered * 100) / total;
+            } else {
+                return -1.0;
+            }
+        } else {
+            return -1.0;
+        }
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchCoveredGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchCoveredGaugeTest.java
@@ -56,6 +56,11 @@ public class CoverageBranchCoveredGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of branches covered", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_branch_covered", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+        Assertions.assertEquals(1, familySamples.samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchMissedGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchMissedGaugeTest.java
@@ -57,7 +57,13 @@ public class CoverageBranchMissedGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of branches missed", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_branch_missed", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchPercentGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchPercentGaugeTest.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoverageBranchPercentGaugeTest extends CoverageTest {
+
+
+    public CoverageBranchPercentGaugeTest() {
+        super(Baseline.PROJECT, Metric.BRANCH);
+    }
+
+    @Test
+    public void testPercentage() {
+        setUpSuccessfulMocksForPercent();
+        CoverageBranchPercentGauge sut = new CoverageBranchPercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of branches in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_branch_percent", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(25.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageBranchPercentGauge sut = new CoverageBranchPercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of branches in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_branch_percent", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchTotalGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageBranchTotalGaugeTest.java
@@ -56,6 +56,12 @@ public class CoverageBranchTotalGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of branches total", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_branch_total", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassCoveredGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassCoveredGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageClassCoveredGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of classes covered", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_class_covered", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassMissedGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassMissedGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageClassMissedGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of classes missed", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_class_missed", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassPercentGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassPercentGaugeTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoverageClassPercentGaugeTest extends CoverageTest {
+
+
+    public CoverageClassPercentGaugeTest() {
+        super(Baseline.PROJECT, Metric.CLASS);
+    }
+
+    @Test
+    public void testPercentage() {
+        setUpSuccessfulMocksForPercent();
+        CoverageClassPercentGauge sut = new CoverageClassPercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of classes in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_class_percent", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(25.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageClassPercentGauge sut = new CoverageClassPercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of classes in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_class_percent", familySamples.name);
+
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassTotalGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageClassTotalGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageClassTotalGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of classes total", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_class_total", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileCoveredGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileCoveredGaugeTest.java
@@ -56,7 +56,12 @@ public class CoverageFileCoveredGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of files covered", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_file_covered", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileMissedGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileMissedGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageFileMissedGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of files missed", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_file_missed", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFilePercentGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFilePercentGaugeTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoverageFilePercentGaugeTest extends CoverageTest {
+
+
+    public CoverageFilePercentGaugeTest() {
+        super(Baseline.PROJECT, Metric.FILE);
+    }
+
+    @Test
+    public void testPercentage() {
+        setUpSuccessfulMocksForPercent();
+        CoverageFilePercentGauge sut = new CoverageFilePercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of files in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_file_percent", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(25.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageFilePercentGauge sut = new CoverageFilePercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of files in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_file_percent", familySamples.name);
+
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileTotalGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageFileTotalGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageFileTotalGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of files total", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_file_total", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionCoveredGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionCoveredGaugeTest.java
@@ -56,7 +56,12 @@ public class CoverageInstructionCoveredGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of instructions covered", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_instruction_covered", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionMissedGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionMissedGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageInstructionMissedGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of instructions missed", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_instruction_missed", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionPercentGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionPercentGaugeTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoverageInstructionPercentGaugeTest extends CoverageTest {
+
+
+    public CoverageInstructionPercentGaugeTest() {
+        super(Baseline.PROJECT, Metric.INSTRUCTION);
+    }
+
+    @Test
+    public void testPercentage() {
+        setUpSuccessfulMocksForPercent();
+        CoverageInstructionPercentGauge sut = new CoverageInstructionPercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of instructions in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_instruction_percent", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(25.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageInstructionPercentGauge sut = new CoverageInstructionPercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of instructions in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_instruction_percent", familySamples.name);
+
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionTotalGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageInstructionTotalGaugeTest.java
@@ -56,7 +56,13 @@ public class CoverageInstructionTotalGaugeTest extends CoverageTest {
         Assertions.assertEquals("Returns the number of instructions total", familySamples.help);
         Assertions.assertEquals("default_jenkins_builds_coverage_instruction_total", familySamples.name);
 
-        Assertions.assertEquals(0, familySamples.samples.size());
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineCoveredGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineCoveredGaugeTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoverageLineCoveredGaugeTest extends CoverageTest {
+
+
+    public CoverageLineCoveredGaugeTest() {
+        super(Baseline.PROJECT, Metric.LINE);
+    }
+
+    @Test
+    public void testCovered() {
+        setUpSuccessfulMocksForCovered();
+        CoverageLineCoveredGauge sut = new CoverageLineCoveredGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the number of lines covered", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_covered", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(10.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageLineCoveredGauge sut = new CoverageLineCoveredGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the number of lines covered", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_covered", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineMissedGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineMissedGaugeTest.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class CoverageLineMissedGaugeTest extends CoverageTest {
+
+
+    public CoverageLineMissedGaugeTest() {
+        super(Baseline.PROJECT, Metric.LINE);
+    }
+
+    @Test
+    public void testMissed() {
+        setUpSuccessfulMocksForMissed();
+        CoverageLineMissedGauge sut = new CoverageLineMissedGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the number of lines missed", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_missed", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(5.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageLineMissedGauge sut = new CoverageLineMissedGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the number of lines missed", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_missed", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLinePercentGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLinePercentGaugeTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class CoverageLinePercentGaugeTest extends CoverageTest {
+
+
+    public CoverageLinePercentGaugeTest() {
+        super(Baseline.PROJECT, Metric.LINE);
+    }
+
+    @Test
+    public void testPercentage() {
+        setUpSuccessfulMocksForPercent();
+        CoverageLinePercentGauge sut = new CoverageLinePercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of lines in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_percent", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(25.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageLinePercentGauge sut = new CoverageLinePercentGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the coverage of lines in percent", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_percent", familySamples.name);
+
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineTotalGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageLineTotalGaugeTest.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.prometheus.collectors.coverage;
+
+import edu.hm.hafner.coverage.Metric;
+import io.jenkins.plugins.coverage.metrics.model.Baseline;
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CoverageLineTotalGaugeTest extends CoverageTest {
+
+
+    public CoverageLineTotalGaugeTest() {
+        super(Baseline.PROJECT, Metric.LINE);
+    }
+
+    @Test
+    public void testMissed() {
+        setUpSuccessfulMocksForTotal();
+        CoverageLineTotalGauge sut = new CoverageLineTotalGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the number of lines total", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_total", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(15.0, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+
+    }
+
+    @Test
+    public void testNothingFailsIfNoCoverageFound() {
+        setUpUnsuccessfulMocks();
+
+        CoverageLineTotalGauge sut = new CoverageLineTotalGauge(new String[]{"job"}, getNamespace(), getSubSystem());
+
+        sut.calculateMetric(mock, new String[]{"myJob"});
+
+        List<Collector.MetricFamilySamples> metricFamilySamples = sut.collect();
+        Assertions.assertEquals(1, metricFamilySamples.size());
+
+        Collector.MetricFamilySamples familySamples = metricFamilySamples.get(0);
+
+        Assertions.assertEquals("Returns the number of lines total", familySamples.help);
+        Assertions.assertEquals("default_jenkins_builds_coverage_line_total", familySamples.name);
+
+        List<Collector.MetricFamilySamples.Sample> samples = familySamples.samples;
+
+        Assertions.assertEquals(1, samples.size());
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0);
+        Assertions.assertEquals(-1, sample.value);
+        Assertions.assertEquals("myJob", sample.labelValues.get(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/coverage/CoverageTest.java
@@ -49,6 +49,19 @@ public abstract class CoverageTest extends MockedRunCollectorTest {
         when(mock.getAction(CoverageBuildAction.class)).thenReturn(mockedCoverageBuildAction);
     }
 
+    protected void setUpSuccessfulMocksForPercent() {
+        CoverageBuildAction mockedCoverageBuildAction = Mockito.mock(CoverageBuildAction.class);
+        Coverage mockedCoverage = Mockito.mock(Coverage.class);
+        when(mockedCoverage.getMetric()).thenReturn(metric);
+        when(mockedCoverage.getTotal()).thenReturn(100);
+        when(mockedCoverage.getCovered()).thenReturn(25);
+        when(mockedCoverageBuildAction.getAllValues(baseline)).thenReturn(List.of(mockedCoverage));
+        when(mock.getAction(CoverageBuildAction.class)).thenReturn(mockedCoverageBuildAction);
+    }
+
+
+
+
 
 
     protected void setUpUnsuccessfulMocks() {


### PR DESCRIPTION
Fixes #611
