### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/DiskUsageCollector.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.prometheus;
 
 import com.cloudbees.simplediskusage.DiskItem;
 import com.cloudbees.simplediskusage.JobDiskItem;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.prometheus.client.Collector;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.prometheus.collectors.CollectorFactory;
@@ -11,7 +12,6 @@ import org.jenkinsci.plugins.prometheus.config.PrometheusConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileStore;
@@ -25,7 +25,7 @@ public class DiskUsageCollector extends Collector {
     private static final Logger LOGGER = LoggerFactory.getLogger(DiskUsageCollector.class);
 
     @Override
-    @Nonnull
+    @NonNull
     public List<MetricFamilySamples> collect() {
 
         if (!PrometheusConfiguration.get().getCollectDiskUsage()) {
@@ -44,7 +44,7 @@ public class DiskUsageCollector extends Collector {
         }
     }
 
-    @Nonnull
+    @NonNull
     private static List<MetricFamilySamples> collectDiskUsage() throws IOException {
         final com.cloudbees.simplediskusage.QuickDiskUsagePlugin diskUsagePlugin = Jenkins.get()
                 .getPlugin(com.cloudbees.simplediskusage.QuickDiskUsagePlugin.class);

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -14,7 +14,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

### Changes proposed

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Checklist

- [x] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@Waschndolos

### Testing done

Confirmed that automated tests pass on Linux with Java 21.
