### PR TITLE
Add new metric for Quiet Mode status

### DIFF
--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -40,6 +40,7 @@ Required Plugin:
 | default_jenkins_up           | Shows if jenkins ready to receive requests | gauge           |
 | default_jenkins_uptime       | Shows time since Jenkins was initialized   | gauge           |
 | default_jenkins_nodes_online | Shows Nodes online status                  | gauge           |
+| default_jenkins_quietdown    | Shows if jenkins is in quiet mode          | gauge           |
 
 ## JobCollector
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollector.java
@@ -23,6 +23,7 @@ public class JenkinsStatusCollector extends Collector {
         collectors.add(factory.createJenkinsCollector(CollectorType.JENKINS_UP_GAUGE, new String[]{}));
         collectors.add(factory.createJenkinsCollector(CollectorType.JENKINS_UPTIME_GAUGE, new String[]{}));
         collectors.add(factory.createJenkinsCollector(CollectorType.NODES_ONLINE_GAUGE, new String[]{"node"}));
+        collectors.add(factory.createJenkinsCollector(CollectorType.JENKINS_QUIETDOWN_GAUGE, new String[]{}));
 
         collectors.forEach(c -> c.calculateMetric(jenkins, new String[]{}));
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/CollectorType.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/CollectorType.java
@@ -5,6 +5,7 @@ public enum CollectorType {
     JENKINS_UP_GAUGE("up"),
     JENKINS_UPTIME_GAUGE("uptime"),
     JENKINS_VERSION_INFO_GAUGE("version"),
+    JENKINS_QUIETDOWN_GAUGE("quietdown"),
     NODES_ONLINE_GAUGE("nodes_online"),
     BUILD_DURATION_GAUGE("build_duration_milliseconds"),
     BUILD_LOGFILE_SIZE_GAUGE("build_logfile_size_bytes"),

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsCollectorFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsCollectorFactory.java
@@ -17,6 +17,8 @@ public class JenkinsCollectorFactory extends BaseCollectorFactory {
         switch (type) {
             case JENKINS_UP_GAUGE:
                 return saveBuildCollector(new JenkinsUpGauge(labelNames, namespace, subsystem));
+            case JENKINS_QUIETDOWN_GAUGE:
+                return saveBuildCollector(new JenkinsQuietDownGauge(labelNames, namespace, subsystem));
             case NODES_ONLINE_GAUGE:
                 if (!isNodeOnlineGaugeEnabled()) {
                     return new NoOpMetricCollector<>();

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsQuietDownGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsQuietDownGauge.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.prometheus.collectors.jenkins;
+
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.prometheus.collectors.BaseMetricCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+public class JenkinsQuietDownGauge extends BaseMetricCollector<Jenkins, Gauge> {
+
+    JenkinsQuietDownGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.JENKINS_QUIETDOWN_GAUGE;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Is Jenkins in quiet mode";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Jenkins jenkinsObject, String[] labelValues) {
+        if (jenkinsObject == null) {
+            return;
+        }
+        this.collector.set(jenkinsObject.isQuietingDown() ? 1 : 0);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollectorTest.java
@@ -22,6 +22,7 @@ public class JenkinsStatusCollectorTest {
 
         PrometheusConfiguration mockedConfig = mock(PrometheusConfiguration.class);
         String namespace = "TestNamespace";
+        int numberOfMetrics = 4;
 
         when(mockedConfig.getDefaultNamespace()).thenReturn(namespace);
         when(mockedConfig.isCollectNodeStatus()).thenReturn(false);
@@ -34,7 +35,7 @@ public class JenkinsStatusCollectorTest {
             JenkinsStatusCollector jenkinsStatusCollector = new JenkinsStatusCollector();
 
             List<MetricFamilySamples> samples = jenkinsStatusCollector.collect();
-            assertEquals(3, samples.size());
+            assertEquals(numberOfMetrics, samples.size());
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsQuietDownGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsQuietDownGaugeTest.java
@@ -1,0 +1,71 @@
+package org.jenkinsci.plugins.prometheus.collectors.jenkins;
+
+import io.prometheus.client.Collector;
+import org.jenkinsci.plugins.prometheus.collectors.testutils.MockedJenkinsTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+public class JenkinsQuietDownGaugeTest extends MockedJenkinsTest {
+
+
+    @Test
+    public void testCollectResultForJenkinsQuietModeEnabled() {
+
+        when(mock.isQuietingDown()).thenReturn(true);
+
+        JenkinsQuietDownGauge sut = new JenkinsQuietDownGauge(new String[]{}, getNamespace(), getSubSystem());
+        sut.calculateMetric(mock, getLabelValues());
+
+        List<Collector.MetricFamilySamples> collect = sut.collect();
+
+        validateMetricFamilySampleListSize(collect, 1);
+
+        Collector.MetricFamilySamples samples = collect.get(0);
+
+        validateNames(samples, new String[]{"default_jenkins_quietdown"});
+        validateMetricFamilySampleSize(samples, 1);
+        validateHelp(samples, "Is Jenkins in quiet mode");
+        validateValue(samples, 0, 1.0);
+    }
+
+
+    @Test
+    public void testCollectResultForJenkinsQuietModeDisabled() {
+
+        when(mock.isQuietingDown()).thenReturn(false);
+
+        JenkinsQuietDownGauge sut = new JenkinsQuietDownGauge(new String[]{}, getNamespace(), getSubSystem());
+        sut.calculateMetric(mock, getLabelValues());
+
+        List<Collector.MetricFamilySamples> collect = sut.collect();
+
+        validateMetricFamilySampleListSize(collect, 1);
+
+        Collector.MetricFamilySamples samples = collect.get(0);
+
+        validateNames(samples, new String[]{"default_jenkins_quietdown"});
+        validateMetricFamilySampleSize(samples, 1);
+        validateHelp(samples, "Is Jenkins in quiet mode");
+        validateValue(samples, 0, 0.0);
+    }
+
+    @Test
+    public void testJenkinsIsNull() {
+        JenkinsQuietDownGauge sut = new JenkinsQuietDownGauge(new String[]{}, getNamespace(), getSubSystem());
+        sut.calculateMetric(null, getLabelValues());
+
+        List<Collector.MetricFamilySamples> collect = sut.collect();
+
+        validateMetricFamilySampleListSize(collect, 1);
+
+        Collector.MetricFamilySamples samples = collect.get(0);
+
+        validateNames(samples, new String[]{"default_jenkins_quietdown"});
+        validateMetricFamilySampleSize(samples, 1);
+        validateHelp(samples, "Is Jenkins in quiet mode");
+        validateValue(samples, 0, 0.0);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new "default_jenkins_quietdown" metric to indicate whether Jenkins is in quiet mode.  It can be used to monitor whether Jenkins is processing new jobs.  It uses the Jenkins.isQuietingDown method to determine the status of the server:

- https://javadoc.jenkins.io/jenkins/model/Jenkins.html#isQuietingDown()

This is a fix for Issue #686 