### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,10 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/builds/JobLabel.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/builds/JobLabel.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.prometheus.collectors.builds;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.prometheus.config.PrometheusConfiguration;
 import org.jenkinsci.plugins.prometheus.util.Runs;
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -7,7 +7,7 @@ import jenkins.YesNoMaybe;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.prometheus.config.disabledmetrics.DisabledMetricConfig;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/util/ConfigurationUtils.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.prometheus.util;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.prometheus.config.PrometheusConfiguration;
 
 public final class ConfigurationUtils {


### PR DESCRIPTION
### Changes proposed

- Remove usages of Commons Lang 2
- Ensure to use direct commons-lang3-api instead of transitively via jackson2-api

### Checklist

- [ ] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@Waschndolos
