### PR TITLE
Add nodes_offline_cause metric exposing why a node is offline

### DIFF
--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -34,13 +34,14 @@ Required Plugin:
 
 ## JenkinsStatusCollector
 
-| metric                       | description                                | Prometheus Type |
-|------------------------------|--------------------------------------------|-----------------|
-| default_jenkins_version      | Shows the jenkins Version                  | info            |
-| default_jenkins_up           | Shows if jenkins ready to receive requests | gauge           |
-| default_jenkins_uptime       | Shows time since Jenkins was initialized   | gauge           |
-| default_jenkins_nodes_online | Shows Nodes online status                  | gauge           |
-| default_jenkins_quietdown    | Shows if jenkins is in quiet mode          | gauge           |
+| metric                              | description                                | Prometheus Type |
+|-------------------------------------|--------------------------------------------|-----------------|
+| default_jenkins_version             | Shows the jenkins Version                  | info            |
+| default_jenkins_up                  | Shows if jenkins ready to receive requests | gauge           |
+| default_jenkins_uptime              | Shows time since Jenkins was initialized   | gauge           |
+| default_jenkins_nodes_online        | Shows Nodes online status                  | gauge           |
+| default_jenkins_nodes_offline_cause | Shows the offline cause per offline node   | gauge           |
+| default_jenkins_quietdown           | Shows if jenkins is in quiet mode          | gauge           |
 
 ## JobCollector
 

--- a/src/main/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/JenkinsStatusCollector.java
@@ -23,6 +23,7 @@ public class JenkinsStatusCollector extends Collector {
         collectors.add(factory.createJenkinsCollector(CollectorType.JENKINS_UP_GAUGE, new String[]{}));
         collectors.add(factory.createJenkinsCollector(CollectorType.JENKINS_UPTIME_GAUGE, new String[]{}));
         collectors.add(factory.createJenkinsCollector(CollectorType.NODES_ONLINE_GAUGE, new String[]{"node"}));
+        collectors.add(factory.createJenkinsCollector(CollectorType.NODES_OFFLINE_CAUSE_GAUGE, new String[]{"node", "cause"}));
         collectors.add(factory.createJenkinsCollector(CollectorType.JENKINS_QUIETDOWN_GAUGE, new String[]{}));
 
         collectors.forEach(c -> c.calculateMetric(jenkins, new String[]{}));

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/CollectorType.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/CollectorType.java
@@ -7,6 +7,7 @@ public enum CollectorType {
     JENKINS_VERSION_INFO_GAUGE("version"),
     JENKINS_QUIETDOWN_GAUGE("quietdown"),
     NODES_ONLINE_GAUGE("nodes_online"),
+    NODES_OFFLINE_CAUSE_GAUGE("nodes_offline_cause"),
     BUILD_DURATION_GAUGE("build_duration_milliseconds"),
     BUILD_WAITING_GAUGE("build_waiting_milliseconds"),
     BUILD_LOGFILE_SIZE_GAUGE("build_logfile_size_bytes"),

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsCollectorFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/JenkinsCollectorFactory.java
@@ -24,6 +24,11 @@ public class JenkinsCollectorFactory extends BaseCollectorFactory {
                     return new NoOpMetricCollector<>();
                 }
                 return saveBuildCollector(new NodesOnlineGauge(labelNames, namespace, subsystem));
+            case NODES_OFFLINE_CAUSE_GAUGE:
+                if (!isNodeOnlineGaugeEnabled()) {
+                    return new NoOpMetricCollector<>();
+                }
+                return saveBuildCollector(new NodesOfflineCauseGauge(labelNames, namespace, subsystem));
             case JENKINS_UPTIME_GAUGE:
                 return saveBuildCollector(new JenkinsUptimeGauge(labelNames, namespace, subsystem));
             case JENKINS_VERSION_INFO_GAUGE:

--- a/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/NodesOfflineCauseGauge.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/NodesOfflineCauseGauge.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.prometheus.collectors.jenkins;
+
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.slaves.OfflineCause;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.prometheus.collectors.BaseMetricCollector;
+import org.jenkinsci.plugins.prometheus.collectors.CollectorType;
+
+public class NodesOfflineCauseGauge extends BaseMetricCollector<Jenkins, Gauge> {
+
+    NodesOfflineCauseGauge(String[] labelNames, String namespace, String subsystem) {
+        super(labelNames, namespace, subsystem);
+    }
+
+    @Override
+    protected CollectorType getCollectorType() {
+        return CollectorType.NODES_OFFLINE_CAUSE_GAUGE;
+    }
+
+    @Override
+    protected String getHelpText() {
+        return "Offline cause per offline node";
+    }
+
+    @Override
+    protected SimpleCollector.Builder<?, Gauge> getCollectorBuilder() {
+        return Gauge.build();
+    }
+
+    @Override
+    public void calculateMetric(Jenkins jenkinsObject, String[] labelValues) {
+        if (jenkinsObject == null) {
+            return;
+        }
+        for (Node node : jenkinsObject.getNodes()) {
+            // Only offline nodes get a series, labelled with their offline cause
+            Computer comp = node.toComputer();
+            if (comp == null || !comp.isOffline()) {
+                continue;
+            }
+            this.collector.labels(node.getNodeName(), causeType(comp.getOfflineCause())).set(1);
+        }
+    }
+
+    private static String causeType(OfflineCause cause) {
+        if (cause == null) {
+            return "Unknown";
+        }
+        String name = cause.getClass().getSimpleName();
+        return name.isEmpty() ? "Unknown" : name;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/NodesOfflineCauseGaugeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/prometheus/collectors/jenkins/NodesOfflineCauseGaugeTest.java
@@ -1,0 +1,112 @@
+package org.jenkinsci.plugins.prometheus.collectors.jenkins;
+
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.slaves.OfflineCause;
+import io.prometheus.client.Collector;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.prometheus.collectors.testutils.MockedJenkinsTest;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodesOfflineCauseGaugeTest extends MockedJenkinsTest {
+
+    static class UserCause extends OfflineCause {
+        @Override
+        public String toString() {
+            return "user";
+        }
+    }
+
+    static class DiskSpace extends OfflineCause {
+        @Override
+        public String toString() {
+            return "disk";
+        }
+    }
+
+    @Test
+    public void testCollectResult() throws Exception {
+
+        setFinalStaticTo123(Jenkins.class.getDeclaredField("VERSION"));
+
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(offlineNode("node1", new UserCause()));
+        nodes.add(onlineNode("node2"));
+        nodes.add(offlineNode("node3", new DiskSpace()));
+        nodes.add(offlineNode("node4", null));
+        nodes.add(offlineNode("node5", new OfflineCause() {
+            @Override
+            public String toString() {
+                return "anon";
+            }
+        }));
+        nodes.add(nullComputerNode());
+        when(mock.getNodes()).thenReturn(nodes);
+
+        NodesOfflineCauseGauge sut = new NodesOfflineCauseGauge(new String[]{"node", "cause"}, getNamespace(), getSubSystem());
+        sut.calculateMetric(mock, getLabelValues());
+
+        List<Collector.MetricFamilySamples> collect = sut.collect();
+
+        validateMetricFamilySampleListSize(collect, 1);
+
+        Collector.MetricFamilySamples samples = collect.get(0);
+        validateNames(samples, new String[]{"default_jenkins_nodes_offline_cause"});
+        // 6 nodes in, only the 4 offline ones with a computer produce a series
+        validateMetricFamilySampleSize(samples, 4);
+
+        Map<String, String> causeByNode = new HashMap<>();
+        for (Collector.MetricFamilySamples.Sample sample : samples.samples) {
+            validateValue(sample, 1.0);
+            int nodeIdx = sample.labelNames.indexOf("node");
+            int causeIdx = sample.labelNames.indexOf("cause");
+            causeByNode.put(sample.labelValues.get(nodeIdx), sample.labelValues.get(causeIdx));
+        }
+
+        assertEquals("UserCause", causeByNode.get("node1"));
+        assertEquals("DiskSpace", causeByNode.get("node3"));
+        assertEquals("Unknown", causeByNode.get("node4"));   // null cause
+        assertEquals("Unknown", causeByNode.get("node5"));   // anonymous cause has no simple name
+        assertFalse(causeByNode.containsKey("node2"));
+    }
+
+    private Node offlineNode(String nodeName, OfflineCause cause) {
+        Node nodeMock = mock(Node.class);
+        Computer computerMock = mock(Computer.class);
+        when(computerMock.isOffline()).thenReturn(true);
+        when(computerMock.getOfflineCause()).thenReturn(cause);
+        when(nodeMock.toComputer()).thenReturn(computerMock);
+        when(nodeMock.getNodeName()).thenReturn(nodeName);
+        return nodeMock;
+    }
+
+    private Node onlineNode(String nodeName) {
+        Node nodeMock = mock(Node.class);
+        Computer computerMock = mock(Computer.class);
+        when(computerMock.isOffline()).thenReturn(false);
+        when(nodeMock.toComputer()).thenReturn(computerMock);
+        return nodeMock;
+    }
+
+    private Node nullComputerNode() {
+        Node nodeMock = mock(Node.class);
+        when(nodeMock.toComputer()).thenReturn(null);
+        return nodeMock;
+    }
+
+    static void setFinalStaticTo123(Field field) throws Exception {
+        field.setAccessible(true);
+        field.set(null, "123");
+    }
+}


### PR DESCRIPTION
The main use case I try to achieve is: implement an easy way to ignore nodes explicitly put offline by the operator (UserCause) from triggering alerts.  The existing nodes_online gauge reports only a binary online/offline state, with no way to tell an operator-initiated offline apart from a node-monitor (disk space, response time) or a dropped channel.

### Changes proposed

Add default_jenkins_nodes_offline_cause{node,cause}, a gauge emitting one series valued 1 for each offline node, where cause is the OfflineCause subclass name (UserCause, ByCLI, DiskSpace, ChannelTermination, ...). Online nodes emit no series. Similarly to nodes_online, it is gated by the collect-node-status configuration.

### Checklist

- [ ] Includes tests covering the new functionality?
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules

### Notify

@Waschndolos
