### PR TITLE
Upgrade Coverage to 3 and raise Jenkins baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.28</version>
+    <version>6.2211.v27f680c93c53</version>
     <relativePath />
   </parent>
 
@@ -22,7 +22,7 @@
     <hpi.bundledArtifacts>simpleclient,simpleclient_common,simpleclient_dropwizard,simpleclient_hotspot,simpleclient_tracer_common,simpleclient_tracer_otel,simpleclient_tracer_otel_agent</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.555</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
 
     <prometheus.simpleclient.version>0.16.0</prometheus.simpleclient.version>
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4969.v6ffa_18d90c9f</version>
+        <version>6931.vea_a_b_c6fd017d</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <prometheus.simpleclient.version>0.16.0</prometheus.simpleclient.version>
 
-    <coverage.version>2.7.0</coverage.version>
+    <coverage.version>3.3305.vf8df16102f76</coverage.version>
 
     <assertj-core.version>3.24.2</assertj-core.version>
     <JUnitParams.version>1.1.1</JUnitParams.version>


### PR DESCRIPTION
## Summary

This supersedes #829 and #830 by combining the Coverage 3 dependency update with its required platform migration in one PR targeting `master`.

Coverage `3.3305.vf8df16102f76` declares Jenkins 2.555.3 and Java 21. The previous Jenkins 2.479.3 baseline and 5.x plugin parent cannot load its Java 21 classes. This PR therefore makes the smallest coherent upgrade:

- upgrade Coverage from `2.7.0` to `3.3305.vf8df16102f76`
- upgrade the plugin parent from `5.28` to `6.2211.v27f680c93c53`
- raise the Jenkins baseline from `2.479.3` to `2.555.3`
- select the matching current `bom-2.555.x`, including the Jackson 3 API level required at test runtime

No Prometheus production or test source is changed.

## Verification

- `mvn -V -B --no-transfer-progress -DskipTests=false clean verify`
  - exact rebased head `e2e26f724ab2e819e0f6d7d9ae44b0fb76be4f38`
  - OpenJDK 26.0.2.1, Maven 3.9.16
  - 263 tests passed, with no failures, errors, or skips
  - Jenkins upper-bound, banned-dependency, and release-dependency gates passed
  - HPI assembly completed with the declared strict bundled-artifact set
  - SpotBugs completed with zero findings
- `git diff --check`
- Jenkins project CI passed all 263 tests on Linux 21, Linux 25, and Windows 25, along with its published compilation, coverage, Checkstyle, PMD, SpotBugs, CPD, Javadoc, and packaging checks

The successful Maven check reports two normal-level warnings that `enforceBytecodeVersion` is deferred to the next invocation; no bytecode result is claimed here.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`